### PR TITLE
Add Castable interface

### DIFF
--- a/core/src/main/java/javax/measure/Quantity.java
+++ b/core/src/main/java/javax/measure/Quantity.java
@@ -7,6 +7,8 @@
  */
 package javax.measure;
 
+import javax.measure.function.Castable;
+
 
 /**
  * <p>
@@ -34,5 +36,5 @@ package javax.measure;
  * @see <a href="http://en.wikipedia.org/wiki/Quantity">Wikipedia: Quantity</a>
  * @version 1.8 ($Revision: 236 $), Date: 2013-12-29
  */
-public interface Quantity<Q extends Quantity<Q>> extends Measurement<Q, Number> {
+public interface Quantity<Q extends Quantity<Q>> extends Measurement<Q, Number>, Castable {
 }

--- a/core/src/main/java/javax/measure/function/Castable.java
+++ b/core/src/main/java/javax/measure/function/Castable.java
@@ -1,0 +1,24 @@
+/**
+ * Unit-API - Units of Measurement API for Java
+ * Copyright (c) 2014 Jean-Marie Dautelle, Werner Keil, V2COM
+ * All rights reserved.
+ * See LICENSE.txt for details.
+ */
+package javax.measure.function;
+
+/**
+ * This interface indices the value can be cast. The classes that can be cast will vary to each implementations.
+ * @author Werner Keil
+ * @version 0.1, $Date: 2014-05-29 $
+ */
+public interface Castable {
+
+	/**
+	 * converts the value to specified class
+	 * @param value class to be converted
+	 * @return the number converted
+	 * @throws NullPointerException if class is null
+	 * @throws UnsupportedOperationException if the class is unsupported
+	 */
+	<T extends java.lang.Number> T getNumber(Class<T> value);
+}


### PR DESCRIPTION
This interface indices the value can be cast. The classes that can be cast will vary to each implementations.
It is useful to expose to a specified class, because in Quantity interface just get as number.
Each implementations each can cast to different kinds of class, for example, ME will cast to numbers wrappers (Double, Integer, Float, etc.) and SE implementations also will cast BigDecimal and BigInteger.
