### PR TITLE
removing comparable in Measure and get in Quantity interface

### DIFF
--- a/src/main/java/javax/measure/Measurement.java
+++ b/src/main/java/javax/measure/Measurement.java
@@ -46,7 +46,7 @@ import javax.measure.function.ConversionOperator;
  * @version 0.21, 2014-09-10
  */
 public interface Measurement<Q extends Quantity<Q>> extends
-		ConversionOperator<Unit<Q>, Measurement<Q>>, Comparable<Measurement<Q>> {
+		ConversionOperator<Unit<Q>, Measurement<Q>> {
 	/**
 	 * Returns the unit of this {@linkplain Measurement}.
 	 *

--- a/src/main/java/javax/measure/Quantity.java
+++ b/src/main/java/javax/measure/Quantity.java
@@ -40,7 +40,7 @@ import javax.measure.function.ValueSupplier;
  * @see Measurement
  * @version 0.14, Date: 2014-09-16
  */
-public interface Quantity<Q extends Quantity<Q>> extends Measurement<Q>, ValueSupplier<Number> {
+public interface Quantity<Q extends Quantity<Q>> extends Measurement<Q>, ValueSupplier<Number>, Comparable<Quantity<Q>> {
 
 	/**
 	 * Returns the sum of this {@code Quantity} with the one specified.

--- a/src/test/java/javax/measure/test/StringMeasurement.java
+++ b/src/test/java/javax/measure/test/StringMeasurement.java
@@ -44,10 +44,4 @@ public final class StringMeasurement<Q extends Quantity<Q>> implements
 		return v + " " + u.getSymbol();
 	}
 
-    @Override
-    public int compareTo(Measurement<Q> o) {
-        // TODO Auto-generated method stub
-        return 0;
-    }
-
 }

--- a/src/test/java/javax/measure/test/TestMeasurement.java
+++ b/src/test/java/javax/measure/test/TestMeasurement.java
@@ -65,10 +65,4 @@ final class TestMeasurement<Q extends Quantity<Q>> implements
 		// TODO Auto-generated method stub
 		return null;
 	}
-
-    @Override
-    public int compareTo(Measurement<Q> o) {
-        // TODO Auto-generated method stub
-        return 0;
-    }
 }

--- a/src/test/java/javax/measure/test/quantity/AreaQuantity.java
+++ b/src/test/java/javax/measure/test/quantity/AreaQuantity.java
@@ -160,8 +160,7 @@ public class AreaQuantity extends TestQuantity<Area> {
 		return null;
 	}
 
-    @Override
-    public int compareTo(Measurement<Area> o) {
+    public int compareTo(Quantity<Area> o) {
         // TODO Auto-generated method stub
         return 0;
     }

--- a/src/test/java/javax/measure/test/quantity/BitQuantity.java
+++ b/src/test/java/javax/measure/test/quantity/BitQuantity.java
@@ -179,7 +179,7 @@ public class BitQuantity extends TestQuantity<Information> {
 	}
 
     @Override
-    public int compareTo(Measurement<Information> o) {
+    public int compareTo(Quantity<Information> o) {
         // TODO Auto-generated method stub
         return 0;
     }

--- a/src/test/java/javax/measure/test/quantity/BitRateQuantity.java
+++ b/src/test/java/javax/measure/test/quantity/BitRateQuantity.java
@@ -147,7 +147,7 @@ public class BitRateQuantity extends TestQuantity<InformationRate> {
 	}
 
     @Override
-    public int compareTo(Measurement<InformationRate> o) {
+    public int compareTo(Quantity<InformationRate> o) {
         // TODO Auto-generated method stub
         return 0;
     }

--- a/src/test/java/javax/measure/test/quantity/DistanceQuantity.java
+++ b/src/test/java/javax/measure/test/quantity/DistanceQuantity.java
@@ -176,7 +176,7 @@ public class DistanceQuantity extends TestQuantity<Length> {
 	}
 
     @Override
-    public int compareTo(Measurement<Length> o) {
+    public int compareTo(Quantity<Length> o) {
         // TODO Auto-generated method stub
         return 0;
     }

--- a/src/test/java/javax/measure/test/quantity/TimeQuantity.java
+++ b/src/test/java/javax/measure/test/quantity/TimeQuantity.java
@@ -7,7 +7,6 @@
  */
 package javax.measure.test.quantity;
 
-import javax.measure.Measurement;
 import javax.measure.Quantity;
 import javax.measure.Unit;
 import javax.measure.quantity.Time;
@@ -129,7 +128,7 @@ public class TimeQuantity extends TestQuantity<Time> {
 	}
 
     @Override
-    public int compareTo(Measurement<Time> o) {
+    public int compareTo(Quantity<Time> o) {
         // TODO Auto-generated method stub
         return 0;
     }

--- a/src/test/java/javax/measure/test/quantity/VolumeQuantity.java
+++ b/src/test/java/javax/measure/test/quantity/VolumeQuantity.java
@@ -7,7 +7,6 @@
  */
 package javax.measure.test.quantity;
 
-import javax.measure.Measurement;
 import javax.measure.Quantity;
 import javax.measure.Unit;
 import javax.measure.quantity.Volume;
@@ -143,7 +142,7 @@ public class VolumeQuantity extends TestQuantity<Volume> {
 	}
 
     @Override
-    public int compareTo(Measurement<Volume> o) {
+    public int compareTo(Quantity<Volume> o) {
         // TODO Auto-generated method stub
         return 0;
     }


### PR DESCRIPTION
Considering this discussion:
The strategy to use Comparable in Quantity
https://java.net/jira/browse/UNITSOFMEASUREMENT-53

:angel:  No one  Override's annotations was added
