### PR TITLE
semantic correctness

### DIFF
--- a/src/main/java/javax/measure/function/QuantityFactory.java
+++ b/src/main/java/javax/measure/function/QuantityFactory.java
@@ -23,6 +23,8 @@ import javax.measure.Unit;
  * @author Werner Keil
  * @version 0.3, $Date: 2014-08-24 $
  */
-public interface QuantityFactory<T extends Number, U extends Unit<R>, R extends Quantity<R>> {
-	R create(T t, U u);
+public interface QuantityFactory <Q extends Quantity<Q>> {
+
+
+    <T extends Number, U extends Unit<Q>> Q create(T number, U unit);
 }


### PR DESCRIPTION
The factory should be:

``` java
QuantityFactory<Acceleration>
```

and not:

``` java
QuantityFactory<Number, Unit<Acceleration>, Acceleration>
```
