### PR TITLE
Change JDK to 7, so that it's closer to Java ME 8.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 		<sourceEncoding>UTF-8</sourceEncoding> <!-- in Maven 3. -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>${sourceEncoding}</project.reporting.outputEncoding>
-		<jdkVersion>1.5</jdkVersion>
+		<jdkVersion>1.7</jdkVersion>
 		<project.build.javaVersion>${jdkVersion}</project.build.javaVersion>
 		<maven.compile.targetLevel>${jdkVersion}</maven.compile.targetLevel>
 		<maven.compile.sourceLevel>${jdkVersion}</maven.compile.sourceLevel>


### PR DESCRIPTION
We should look into having the Java ME 8 JSRs as dependencies and remove
"JRE System Library" as dependency, or something like that...
