### PR TITLE
Fix a few small typos in the API documentation

### DIFF
--- a/src/main/java/javax/measure/Unit.java
+++ b/src/main/java/javax/measure/Unit.java
@@ -155,7 +155,7 @@ public interface Unit<Q extends Quantity<Q>> {
    * this unit's dimension do not match. For example:
    *
    * <code>
-   *      {@literal Unit<Speed>} C = METRE.times(299792458).divide(SECOND).asType(Speed.class);
+   *      {@literal Unit<Speed>} C = METRE.multiply(299792458).divide(SECOND).asType(Speed.class);
    * </code>
    *
    * @param <T>
@@ -217,7 +217,7 @@ public interface Unit<Q extends Quantity<Q>> {
    *
    * <code>
    *     {@literal Unit<Angle>} RADIAN = ONE.alternate("rad").asType(Angle.class);<br>
-   *     {@literal Unit<Force>} NEWTON = METRE.times(KILOGRAM).divide(SECOND.pow(2)).alternate("N").asType(Force.class);<br>
+   *     {@literal Unit<Force>} NEWTON = METRE.multiply(KILOGRAM).divide(SECOND.pow(2)).alternate("N").asType(Force.class);<br>
    *     {@literal Unit<Pressure>} PASCAL = NEWTON.divide(METRE.pow(2)).alternate("Pa").asType(Pressure.class);<br>
    * </code>
    *

--- a/src/main/java/javax/measure/format/UnitFormat.java
+++ b/src/main/java/javax/measure/format/UnitFormat.java
@@ -38,7 +38,7 @@ import javax.measure.Unit;
  *
  * <h4><a name="synchronization">Synchronization</a></h4>
  * <p>
- * Instances of this class are not required to be thread-safe. It is recommended to of separate format instances for each thread. If multiple threads
+ * Instances of this class are not required to be thread-safe. It is recommended to use separate format instances for each thread. If multiple threads
  * access a format concurrently, it must be synchronized externally.
  * <p>
  *


### PR DESCRIPTION
- Updated a UnitFormat.java comment to improve the grammar.
- The unit times() method is nowadays named multiply().