### PR TITLE
Partial support of JDK9 module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
 		<project.build.javaVersion>${jdkVersion}</project.build.javaVersion>
 		<maven.compile.targetLevel>${jdkVersion}</maven.compile.targetLevel>
 		<maven.compile.sourceLevel>${jdkVersion}</maven.compile.sourceLevel>
+		<compile.exclude.files>module-info.java</compile.exclude.files>
 
 		<!-- Plugins -->
 		<felix.version>3.3.0</felix.version>
@@ -266,7 +267,7 @@
 					<version>0.5.2</version>
 				</plugin>
 
-				<!--This plugin's configuration is used to store Eclipse m2e settings 
+				<!--This plugin's configuration is used to store Eclipse m2e settings
 					only. It has no influence on the Maven build itself. -->
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>
@@ -328,6 +329,9 @@
 					<source>${maven.compile.sourceLevel}</source>
 					<target>${maven.compile.targetLevel}</target>
 					<encoding>${project.build.sourceEncoding}</encoding>
+					<excludes>
+						<exclude>${compile.exclude.files}</exclude>
+					</excludes>
 				</configuration>
 			</plugin>
 
@@ -465,7 +469,7 @@
 					</execution>
 				</executions>
 			</plugin>
-			
+
 			<!-- Packaging (OSGi bundle) -->
 			<plugin>
 				<groupId>org.apache.felix</groupId>
@@ -674,11 +678,18 @@
 				<jdkVersion>1.8</jdkVersion>
 			</properties>
 		</profile>
+		<profile>
+			<id>jdk9</id>
+			<properties>
+				<jdkVersion>9</jdkVersion>
+				<compile.exclude.files>none</compile.exclude.files>
+			</properties>
+		</profile>
 
 		<!-- Individual JARs -->
 		<profile>
 			<id>core-jar</id>
-			<!-- This profile builds only the core (root level) elements into a separate 
+			<!-- This profile builds only the core (root level) elements into a separate
 				-core.jar file -->
 			<activation>
 				<activeByDefault>false</activeByDefault>
@@ -711,7 +722,7 @@
 
 		<profile>
 			<id>format-jar</id>
-			<!-- This profile builds (optional) format elements into separate JAR 
+			<!-- This profile builds (optional) format elements into separate JAR
 				files -->
 			<build>
 				<plugins>
@@ -794,7 +805,7 @@
 		<!-- Profile JARs -->
 		<profile>
 			<id>format-profile</id>
-			<!-- This profile builds the Format Profile (core+format) into a separate 
+			<!-- This profile builds the Format Profile (core+format) into a separate
 				jar file -->
 			<activation>
 				<activeByDefault>false</activeByDefault>
@@ -826,7 +837,7 @@
 
 		<profile>
 			<id>spi-profile</id>
-			<!-- This profile builds the SPI Profile (core+format+spi) into a separate 
+			<!-- This profile builds the SPI Profile (core+format+spi) into a separate
 				jar file -->
 			<activation>
 				<activeByDefault>false</activeByDefault>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,33 @@
+/*
+ * Units of Measurement API
+ * Copyright (c) 2014-2016, Jean-Marie Dautelle, Werner Keil, V2COM.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of JSR-363 nor the names of its contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+module java.measure {
+    requires java.logging;
+    uses javax.measure.spi.ServiceProvider;
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -29,5 +29,9 @@
  */
 module java.measure {
     requires java.logging;
+    exports javax.measure;
+    exports javax.measure.format;
+    exports javax.measure.quantity;
+    exports javax.measure.spi;
     uses javax.measure.spi.ServiceProvider;
 }


### PR DESCRIPTION
This pull request adds a `jdk9` profile in the `pom.xml` file and a `module-info.java` file is source code. The `module-info.java` file is skipped in all profiles except `jdk9`. Due to [MCOMPILER-294](https://issues.apache.org/jira/browse/MCOMPILER-294) issue, tests can not yet be compiled with Maven. Javadoc generation also fails, so the following command line have to be used:

`mvn clean install -Pjdk9 -Dmaven.test.skip=true -Dmaven.javadoc.skip=true`

In addition, as of June 26th 2017, the following changes need to be done in the `pom.xml` file in order to compile with JDK9. Those changes are not included in this pull request since we assume that the need for them is temporary:

- `<packaging>bundle</packaging>` element need to be changed into `<packaging>jar</packaging>` since `maven-bundle-plugin` version 3.3.0 does not seem to be compatible with JDK9 (but `maven-jar-plugin` is okay)
- The Javadoc `attach-sources` execution needs to be removed.
