### PR TITLE
Upgrade Maven compiler plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.6.1</version>
+				<version>3.6.2</version>
 				<configuration>
 					<source>${maven.compile.sourceLevel}</source>
 					<target>${maven.compile.targetLevel}</target>


### PR DESCRIPTION
Latest maven-compiler-plugin version fixes compilation issue of test classes with JDK9.