### PR TITLE
Remove default method implementations in UnitConverter

### DIFF
--- a/src/main/java/javax/measure/UnitConverter.java
+++ b/src/main/java/javax/measure/UnitConverter.java
@@ -53,9 +53,7 @@ public interface UnitConverter {
    *
    * @return {@code true} if this converter is an identity converter.
    */
-  default boolean isIdentity() {
-      return false;
-  }
+  boolean isIdentity();
 
   /**
    * Indicates if this converter is linear. A converter is linear if:
@@ -77,9 +75,7 @@ public interface UnitConverter {
    *
    * @return {@code true} if this converter is linear; {@code false} otherwise.
    */
-  default boolean isLinear() {
-      return false;
-  }
+  boolean isLinear();
 
   /**
    * Returns the inverse of this converter. If {@code x} is a valid value, then {@code x == inverse().convert(convert(x))} to within the accuracy of


### PR DESCRIPTION
Remove default method implementations in UnitConverter because those methods can not know how to fulfill the contract described in their javadoc. See issue #76.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/unit-api/82)
<!-- Reviewable:end -->
