### PR TITLE
Do not provide default implementation for SystemOfUnitsService.getPrefix

### DIFF
--- a/src/main/java/javax/measure/spi/SystemOfUnitsService.java
+++ b/src/main/java/javax/measure/spi/SystemOfUnitsService.java
@@ -30,8 +30,6 @@
 package javax.measure.spi;
 
 import java.util.Collection;
-import java.util.Collections;
-import java.util.EnumSet;
 import java.util.Set;
 import javax.measure.Prefix;
 
@@ -105,8 +103,5 @@ public interface SystemOfUnitsService {
 	 *             implementation.
 	 * @since 2.0
 	 */
-	@SuppressWarnings("unchecked")
-	default Set<Prefix> getPrefixes(@SuppressWarnings("rawtypes") Class prefixType) {
-		return Collections.<Prefix>unmodifiableSet(EnumSet.allOf(prefixType.asSubclass(Enum.class)));
-	}
+	Set<Prefix> getPrefixes(Class<? extends Prefix> prefixType);
 }

--- a/src/test/java/javax/measure/spi/TestSystemOfUnitsService.java
+++ b/src/test/java/javax/measure/spi/TestSystemOfUnitsService.java
@@ -30,11 +30,12 @@
 package javax.measure.spi;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
-import javax.measure.spi.SystemOfUnits;
-import javax.measure.spi.SystemOfUnitsService;
+import javax.measure.Prefix;
 
 /**
  * @author <a href="mailto:units@catmedia.us">Werner Keil</a>
@@ -57,5 +58,11 @@ class TestSystemOfUnitsService implements SystemOfUnitsService {
   @Override
   public SystemOfUnits getSystemOfUnits() {
     return getSystemOfUnits("");
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Set<Prefix> getPrefixes(Class<? extends Prefix> prefixType) {
+    return (Set<Prefix>) Collections.unmodifiableSet(EnumSet.allOf(prefixType.asSubclass(Enum.class)));
   }
 }


### PR DESCRIPTION
Interface `SystemOfUnitsService` provides a default implementation for `getPrefixes(Class)` method, but that default assumes an implementation based on `java.lang.Enum`. Default methods in Unit-API interfaces should work without making any assumption on implementation choices. If knowledge or assumptions about details is required, then we should let implementors provide this method.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/unit-api/107)
<!-- Reviewable:end -->
