### PR TITLE
Enabled sonarcloud.io code analysis

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,6 +112,10 @@ jobs:
       
       # share coverage
       - run: mvn test jacoco:report coveralls:report -DsourceEncoding=UTF-8
+      
+      # run code analysis using sonarqube
+      - run: mvn sonar:sonar -DsourceEncoding=UTF-8 -Dsonar.organization=$SONARCLOUD_ORG -Dsonar.projectKey=$SONARCLOUD_PROJECT_KEY -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONARCLOUD_LOGIN
+      
 workflows:
   version: 2
   clean_build_deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ jobs:
       - run: mvn test jacoco:report coveralls:report -DsourceEncoding=UTF-8
       
       # run code analysis using sonarqube
-      - run: mvn sonar:sonar -DsourceEncoding=UTF-8 -Dsonar.organization=$SONARCLOUD_ORG -Dsonar.projectKey=$SONARCLOUD_PROJECT_KEY -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=$SONARCLOUD_LOGIN
+      - run: mvn sonar:sonar -DsourceEncoding=UTF-8
       
 workflows:
   version: 2

--- a/pom.xml
+++ b/pom.xml
@@ -1042,5 +1042,18 @@
 				</plugins>
 			</build>
 		</profile>
+		
+		<profile>
+			<id>sonar</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<properties>
+				<sonar.host.url>https://sonarcloud.io</sonar.host.url>
+				<sonar.projectKey>${env.SONARCLOUD_PROJECT_KEY}</sonar.projectKey>
+				<sonar.login>${env.SONARCLOUD_LOGIN}</sonar.login>
+				<sonar.organization>${env.SONARCLOUD_ORG}</sonar.organization>
+			</properties>
+		</profile>
 	</profiles>
 </project>


### PR DESCRIPTION
To enable SonarQube code analysis in Sonarcloud.io, following environment variables have to be set in Circle-CI:

$SONARCLOUD_ORG - the organisation, could be `unitsofmeasurement.github.io`
$SONARCLOUD_PROJECT_KEY - defines the token where to reach the analysis results, ideally it would be `javax.measure:unit-api` but this is already occupied so an alternate project key is required - well I have no write access to publish any contents into https://sonarcloud.io/dashboard?id=javax.measure%3Aunit-api - which is okay.
$SONARCLOUD_LOGIN - login token to be created within the sonarcloud.io account to be used

I've tested this in Circle-CI using my own custom namespace.
https://sonarcloud.io/dashboard?id=net.raumzeitfalle.javax.measure%3Aunit-api

Solves #48 

Regards!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/unit-api/111)
<!-- Reviewable:end -->
