### PR TITLE
Tuning in prefixes management

### DIFF
--- a/src/main/java/javax/measure/BinaryPrefix.java
+++ b/src/main/java/javax/measure/BinaryPrefix.java
@@ -38,14 +38,22 @@ package javax.measure;
  * @since 2.0
  */
 public enum BinaryPrefix implements Prefix {
-  KIBI("Ki", 1024, 1), //
-  MEBI("Mi", 1024, 2), //
-  GIBI("Gi", 1024, 3), //
-  TEBI("Ti", 1024, 4), //
-  PEBI("Pi", 1024, 5), //
-  EXBI("Ei", 1024, 6), //
-  ZEBI("Zi", 1024, 7), //
-  YOBI("Yi", 1024, 8);
+  /** Prefix for 1024. */
+  KIBI("Ki", 1),
+  /** Prefix for 1024<sup>2</sup>. */
+  MEBI("Mi", 2),
+  /** Prefix for 1024<sup>3</sup>. */
+  GIBI("Gi", 3),
+  /** Prefix for 1024<sup>4</sup>. */
+  TEBI("Ti", 4),
+  /** Prefix for 1024<sup>5</sup>. */
+  PEBI("Pi", 5),
+  /** Prefix for 1024<sup>6</sup>. */
+  EXBI("Ei", 6),
+  /** Prefix for 1024<sup>7</sup>. */
+  ZEBI("Zi", 7),
+  /** Prefix for 1024<sup>8</sup>. */
+  YOBI("Yi", 8);
 
   /**
    * The symbol of this prefix, as returned by {@link #getSymbol}.
@@ -56,28 +64,20 @@ public enum BinaryPrefix implements Prefix {
   private final String symbol;
 
   /**
-   * Base part of the associated factor in base^exponent representation.
-   */
-  private int base;
-
-  /**
    * Exponent part of the associated factor in base^exponent representation.
    */
-  private int exponent;
+  private final int exponent;
 
   /**
    * Creates a new prefix.
    *
    * @param symbol
    *          the symbol of this prefix.
-   * @param base
-   *          part of the associated factor in base^exponent representation.
    * @param exponent
    *          part of the associated factor in base^exponent representation.
    */
-  private BinaryPrefix(String symbol, int base, int exponent) {
+  private BinaryPrefix(String symbol, int exponent) {
     this.symbol = symbol;
-    this.base = base;
     this.exponent = exponent;
   }
 
@@ -200,7 +200,7 @@ public enum BinaryPrefix implements Prefix {
    */
   @Override
   public int getBase() {
-    return base;
+    return 1024;
   }
 
   /**

--- a/src/main/java/javax/measure/MetricPrefix.java
+++ b/src/main/java/javax/measure/MetricPrefix.java
@@ -50,26 +50,46 @@ package javax.measure;
  * @since 2.0
  */
 public enum MetricPrefix implements Prefix {
-  YOTTA("Y", 10, 24), //
-  ZETTA("Z", 10, 21), //
-  EXA("E", 10, 18), //
-  PETA("P", 10, 15), //
-  TERA("T", 10, 12), //
-  GIGA("G", 10, 9), //
-  MEGA("M", 10, 6), //
-  KILO("k", 10, 3), //
-  HECTO("h", 10, 2), //
-  DEKA("da", 10, 1), //
-  DECI("d", 10, -1), //
-  CENTI("c", 10, -2), //
-  MILLI("m", 10, -3), //
-  MICRO("µ", 10, -6), //
-  NANO("n", 10, -9), //
-  PICO("p", 10, -12), //
-  FEMTO("f", 10, -15), //
-  ATTO("a", 10, -18), //
-  ZEPTO("z", 10, -21), //
-  YOCTO("y", 10, -24);
+  /** Prefix for 10<sup>24</sup>. */
+  YOTTA("Y", 24),
+  /** Prefix for 10<sup>21</sup>. */
+  ZETTA("Z", 21),
+  /** Prefix for 10<sup>18</sup>. */
+  EXA("E", 18),
+  /** Prefix for 10<sup>15</sup>. */
+  PETA("P", 15),
+  /** Prefix for 10<sup>12</sup>. */
+  TERA("T", 12),
+  /** Prefix for 10<sup>9</sup>. */
+  GIGA("G", 9),
+  /** Prefix for 10<sup>6</sup>. */
+  MEGA("M", 6),
+  /** Prefix for 10<sup>3</sup>. */
+  KILO("k", 3),
+  /** Prefix for 10<sup>2</sup>. */
+  HECTO("h", 2),
+  /** Prefix for 10<sup>1</sup>. */
+  DEKA("da", 1),
+  /** Prefix for 10<sup>-1</sup>. */
+  DECI("d", -1),
+  /** Prefix for 10<sup>-2</sup>. */
+  CENTI("c", -2),
+  /** Prefix for 10<sup>-3</sup>. */
+  MILLI("m", -3),
+  /** Prefix for 10<sup>-6</sup>. */
+  MICRO("µ", -6),
+  /** Prefix for 10<sup>-9</sup>. */
+  NANO("n", -9),
+  /** Prefix for 10<sup>-12</sup>. */
+  PICO("p", -12),
+  /** Prefix for 10<sup>-15</sup>. */
+  FEMTO("f", -15),
+  /** Prefix for 10<sup>-18</sup>. */
+  ATTO("a", -18),
+  /** Prefix for 10<sup>-21</sup>. */
+  ZEPTO("z", -21),
+  /** Prefix for 10<sup>-24</sup>. */
+  YOCTO("y", -24);
 
   /**
    * The symbol of this prefix, as returned by {@link #getSymbol}.
@@ -80,28 +100,20 @@ public enum MetricPrefix implements Prefix {
   private final String symbol;
 
   /**
-   * Base part of the associated factor in base^exponent representation.
-   */
-  private int base;
-
-  /**
    * Exponent part of the associated factor in base^exponent representation.
    */
-  private int exponent;
+  private final int exponent;
 
   /**
    * Creates a new prefix.
    *
    * @param symbol
    *          the symbol of this prefix.
-   * @param base
-   *          part of the associated factor in base^exponent representation.
    * @param exponent
    *          part of the associated factor in base^exponent representation.
    */
-  private MetricPrefix(String symbol, int base, int exponent) {
+  private MetricPrefix(String symbol, int exponent) {
     this.symbol = symbol;
-    this.base = base;
     this.exponent = exponent;
   }
 
@@ -376,11 +388,11 @@ public enum MetricPrefix implements Prefix {
   }
 
   /**
-   * Base part of the associated factor in base^exponent representation.
+   * Base part of the associated factor in base^exponent representation. For metric prefix, this is always 10.
    */
   @Override
   public int getBase() {
-    return base;
+    return 10;
   }
 
   /**

--- a/src/main/java/javax/measure/Unit.java
+++ b/src/main/java/javax/measure/Unit.java
@@ -304,8 +304,7 @@ public interface Unit<Q extends Quantity<Q>> {
   Unit<?> divide(Unit<?> divisor);
 
   /**
-   * Returns an unit that is the n-th (integer) root of this unit.<br/>
-   * Equivalent to the mathematical expression {@code unit^(1/n)}.
+   * Returns an unit that is the n-th (integer) root of this unit. Equivalent to the mathematical expression {@code unit^(1/n)}.
    *
    * @param n
    *          an integer giving the root's order as in 'n-th root'
@@ -316,8 +315,7 @@ public interface Unit<Q extends Quantity<Q>> {
   Unit<?> root(int n);
 
   /**
-   * Returns an unit raised to the n-th (integer) power of this unit.<br/>
-   * Equivalent to the mathematical expression {@code unit^n}.
+   * Returns an unit raised to the n-th (integer) power of this unit. Equivalent to the mathematical expression {@code unit^n}.
    *
    * @param n
    *          the exponent.
@@ -327,11 +325,12 @@ public interface Unit<Q extends Quantity<Q>> {
 
   /**
    * Returns the unit derived from this unit using the specified converter. The converter does not need to be linear. For example:<br>
-   * <code>
+   *
+   * <pre>
    *     {@literal Unit<Dimensionless>} DECIBEL = Unit.ONE.transform(
    *         new LogConverter(10).inverse().concatenate(
    *             new RationalConverter(1, 10)));
-   * </code>
+   * </pre>
    *
    * @param operation
    *          the converter from the transformed unit to this unit.
@@ -359,7 +358,8 @@ public interface Unit<Q extends Quantity<Q>> {
    * Returns a new unit equal to this unit prefixed by the specified {@code prefix}.
    *
    * @param prefix
-   * @return
+   *          the prefix to apply on this unit.
+   * @return the unit with the given prefix applied.
    */
   Unit<Q> prefix(Prefix prefix);
 }

--- a/src/test/java/javax/measure/spi/ServiceProviderTest.java
+++ b/src/test/java/javax/measure/spi/ServiceProviderTest.java
@@ -82,7 +82,7 @@ public class ServiceProviderTest {
   public void testGetMetricPrefixes() {
     final ServiceProvider testProv = new TestServiceProvider();
     final SystemOfUnitsService service = testProv.getSystemOfUnitsService();
-    Collection<Prefix> prefixes = service.getPrefixes(MetricPrefix.class);
+    Collection<MetricPrefix> prefixes = service.getPrefixes(MetricPrefix.class);
     assertNotNull(prefixes);
     assertEquals(20, prefixes.size());
   }
@@ -92,7 +92,7 @@ public class ServiceProviderTest {
     final ServiceProvider testProv = new TestServiceProvider();
     final SystemOfUnitsService service = testProv.getSystemOfUnitsService();
     assertNotNull(service);
-    Collection<Prefix> prefixes = service.getPrefixes(BinaryPrefix.class);
+    Collection<BinaryPrefix> prefixes = service.getPrefixes(BinaryPrefix.class);
     assertNotNull(prefixes);
     assertEquals(8, prefixes.size());
   }
@@ -103,7 +103,7 @@ public class ServiceProviderTest {
     final SystemOfUnitsService service = testProv.getSystemOfUnitsService();
     assertNotNull(service);
     @SuppressWarnings("unused")
-    Collection<Prefix> prefixes = service.getPrefixes(String.class);
+    Collection<Prefix> prefixes = service.getPrefixes((Class) String.class);
   }
 
   @Test(expected = ClassCastException.class)
@@ -112,7 +112,7 @@ public class ServiceProviderTest {
     final SystemOfUnitsService service = testProv.getSystemOfUnitsService();
     assertNotNull(service);
     @SuppressWarnings("unused")
-    Collection<Prefix> prefixes = service.getPrefixes(DummyEnum.class);
+    Collection<Prefix> prefixes = service.getPrefixes((Class) DummyEnum.class);
   }
 
   private static final class TestServiceProvider extends ServiceProvider {


### PR DESCRIPTION
This merge request contains two changes:

* Parameterize `SystemOfUnitsService.getPrefixes(Class)`, replacing `Class` by `Class<P extends Prefix>`.
* Replace the `base` attribute in `MetricPrefix` and `BinaryPrefix` by constant value in `getBase()` methods, since all enumeration values in those classes have the same base.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/unit-api/116)
<!-- Reviewable:end -->
