### PR TITLE
Create a multi-release JAR file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,11 +61,11 @@
         <sourceEncoding>UTF-8</sourceEncoding> <!-- in Maven 3. -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>${sourceEncoding}</project.reporting.outputEncoding>
-        <jdkVersion>1.8</jdkVersion>
+        <jdkVersion>8</jdkVersion>
+        <jdkOptionalVersion>9</jdkOptionalVersion>
         <project.build.javaVersion>${jdkVersion}</project.build.javaVersion>
         <maven.compile.targetLevel>${jdkVersion}</maven.compile.targetLevel>
         <maven.compile.sourceLevel>${jdkVersion}</maven.compile.sourceLevel>
-        <compile.exclude.files>module-info.java</compile.exclude.files>
         <additionalparam>-Xdoclint:none</additionalparam>
         <thisYear>2018</thisYear>
 
@@ -73,12 +73,11 @@
         <felix.version>3.4.0</felix.version>
         <github.maven.version>0.12</github.maven.version>
         <github.global.server>github</github.global.server>
-        <maven.resources.version>3.0.2</maven.resources.version>
-        <maven.compile.version>3.7.0</maven.compile.version>
-        <maven.site.version>3.7</maven.site.version>
-        <maven.jar.version>3.0.2</maven.jar.version>
-        <maven.javadoc.version>3.0.0-M1</maven.javadoc.version>
-        <!-- FIXME in javadoc 3.0.0 the Xdoclint:none needs to be applied differently -->
+        <maven.resources.version>3.1.0</maven.resources.version>
+        <maven.compile.version>3.8.0</maven.compile.version>
+        <maven.site.version>3.7.1</maven.site.version>
+        <maven.jar.version>3.1.0</maven.jar.version>
+        <maven.javadoc.version>3.0.1</maven.javadoc.version>
         <jacoco.plugin.version>0.8.1</jacoco.plugin.version>
     </properties>
 
@@ -282,10 +281,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven.compile.version}</version>
-                    <configuration>
-                        <source>9</source>
-                        <target>9</target>
-                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>1.8</version>
                 </plugin>
 
                 <!-- License -->
@@ -363,11 +363,6 @@
                                         <versionRange>
                                             [1.0.0.Beta1,)
                                         </versionRange>
-                                        <goals>
-                                            <goal>
-                                                generate-module-info
-                                            </goal>
-                                        </goals>
                                     </pluginExecutionFilter>
                                     <action>
                                         <ignore></ignore>
@@ -385,37 +380,32 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>${maven.compile.targetLevel}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-antrun-plugin</artifactId>
+              <executions>
+                <execution>
+                  <phase>prepare-package</phase>
+                  <goals><goal>run</goal></goals>
+                  <configuration>
+                    <target>
+                      <mkdir dir       = "${project.build.directory}/classes/META-INF/versions/${jdkOptionalVersion}"/>
+                      <javac destdir   = "${project.build.directory}/classes/META-INF/versions/${jdkOptionalVersion}"
+                             srcdir    = "${project.basedir}/src/main/jdk${jdkOptionalVersion}"
+                             includeAntRuntime = "false">
 
-                <executions>
-                    <execution>
-                        <id>default-compile</id>
-                        <configuration>
-                            <!-- compile everything to ensure module-info contains right entries -->
-                            <!-- required when JAVA_HOME is JDK 8 or below -->
-                            <jdkToolchain>
-                                <version>9</version>
-                            </jdkToolchain>
-                            <release>9</release>
-                            <sources>
-                                <source>src/main/java-mr/9</source>
-                            </sources>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>base-compile</id>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                        <!-- recompile everything for target VM except the module-info.java -->
-                        <configuration>
-                            <source>${maven.compile.sourceLevel}</source>
-                            <target>${maven.compile.targetLevel}</target>
-                            <excludes>
-                                <exclude>java/measure/${compile.exclude.files}</exclude>
-                            </excludes>
-                        </configuration>
-                    </execution>
-                </executions>
+                          <!-- TODO: use release attribute instead after next plugin release.
+                               https://issues.apache.org/jira/browse/MANTRUN-214 -->
+                          <compilerarg line="--release=${jdkOptionalVersion} --patch-module java.measure=${project.build.directory}/classes"/>
+                      </javac>
+                    </target>
+                  </configuration>
+                </execution>
+              </executions>
             </plugin>
 
             <!-- Coverage -->
@@ -423,12 +413,6 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco.plugin.version}</version>
-                <configuration>
-                    <destfile>${basedir}/target/coverage-reports/jacoco-unit.exec</destfile>
-                    <datafile>${basedir}/target/coverage-reports/jacoco-unit.exec</datafile>
-                    <excludes>
-                    </excludes>
-                </configuration>
                 <executions>
                     <execution>
                         <id>pre-unit-test</id>
@@ -529,9 +513,6 @@
                             <head>Implementation Requirements:</head>
                         </tag>
                     </tags>
-                    <sourceFileExcludes>
-                        <exclude>**/module-info.java</exclude>
-                    </sourceFileExcludes>
                 </configuration>
             </plugin>
 
@@ -552,6 +533,7 @@
                             <Implementation-Vendor>Unit-API contributors</Implementation-Vendor>
                             <Implementation-URL>http://unitsofmeasurement.github.io</Implementation-URL>
                             <Automatic-Module-Name>java.measure</Automatic-Module-Name>
+                            <Multi-Release>true</Multi-Release>
                         </manifestEntries>
                     </archive>
                 </configuration>
@@ -698,7 +680,6 @@
                 <version>3.8</version>
                 <configuration>
                     <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
-                    <targetJdk>${project.build.javaVersion}</targetJdk>
                 </configuration>
             </plugin>
 
@@ -956,67 +937,6 @@
                         </executions>
                     </plugin>
                 </plugins>
-            </build>
-        </profile>
-
-        <profile>
-            <id>modGen</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.moditect</groupId>
-                        <artifactId>moditect-maven-plugin</artifactId>
-                        <version>1.0.0.Beta1</version>
-                        <executions>
-                            <execution>
-                                <id>generate-module-info</id>
-                                <phase>generate-sources</phase>
-                                <goals>
-                                    <goal>generate-module-info</goal>
-                                </goals>
-                                <configuration>
-                                    <modules>
-                                        <module>
-                                            <artifact>
-                                                <groupId>javax.measure</groupId>
-                                                <artifactId>unit-api</artifactId>
-                                                <version>2.0-SNAPSHOT</version>
-                                            </artifact>
-                                            <additionalDependencies>
-                                                <dependency>
-                                                    <groupId>junit</groupId>
-                                                    <artifactId>junit</artifactId>
-                                                    <version>4.12</version>
-                                                </dependency>
-                                            </additionalDependencies>
-                                            <moduleInfo>
-                                                <name>java.measure</name>
-                                                <exports>
-                                                    *;
-                                                </exports>
-                                                <requires>
-                                                    *;
-                                                </requires>
-                                                <uses>
-                                                    javax.measure.spi.FormatService;
-                                                    javax.measure.spi.QuantityFactory;
-                                                    javax.measure.spi.ServiceProvider;
-                                                    javax.measure.spi.SystemOfUnitsService;
-                                                    javax.measure.spi.UnitFormatService;
-                                                    javax.measure.format.QuantityFormat;
-                                                    javax.measure.format.UnitFormat;
-                                                </uses>
-                                                <addServiceUses>true</addServiceUses>
-                                            </moduleInfo>
-                                        </module>
-                                    </modules>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-
-                </plugins>
-
             </build>
         </profile>
 

--- a/src/main/java/javax/measure/format/ParserException.java
+++ b/src/main/java/javax/measure/format/ParserException.java
@@ -37,6 +37,7 @@ package javax.measure.format;
  * @since 1.0
  * @deprecated Use {@link MeasurementParseException}, this exception will be removed in a future version, it is here for backward compatibility only.
  */
+@Deprecated
 public class ParserException extends MeasurementParseException {
 
     private static final long serialVersionUID = -3179553925611520368L;

--- a/src/main/java/javax/measure/spi/UnitFormatService.java
+++ b/src/main/java/javax/measure/spi/UnitFormatService.java
@@ -44,6 +44,7 @@ import javax.measure.format.UnitFormat;
  * @since 1.0
  * @deprecated To be merged with {@link FormatService}, and removed in a future version, it is here for backward compatibility only.
  */
+@Deprecated
 public interface UnitFormatService {
 
     /**

--- a/src/main/jdk9/javax/measure/spi/ServiceProvider.java
+++ b/src/main/jdk9/javax/measure/spi/ServiceProvider.java
@@ -35,8 +35,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.ServiceLoader;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.measure.Quantity;
 import javax.measure.format.QuantityFormat;
 import javax.measure.format.UnitFormat;
@@ -47,7 +45,7 @@ import javax.measure.format.UnitFormat;
  * All the methods in this class are safe to use by multiple concurrent threads.
  * </p>
  *
- * @version 1.4, October 7, 2018
+ * @version 1.2, September 25, 2018
  * @author Werner Keil
  * @author Martin Desruisseaux
  * @since 1.0
@@ -147,7 +145,7 @@ public abstract class ServiceProvider {
      *
      * @return all available service providers.
      */
-    public static final List<ServiceProvider> available() {
+    public static List<ServiceProvider> available() {
         return Arrays.asList(getProviders());
     }
 
@@ -164,8 +162,6 @@ public abstract class ServiceProvider {
      *             if available service providers do not contain a provider with the specified name
      * @throws NullPointerException
      *             if {@code name} is null
-     * @see #toString()
-     * @since 2.0
      */
     public static ServiceProvider of(String name) {
         Objects.requireNonNull(name);
@@ -190,7 +186,7 @@ public abstract class ServiceProvider {
      * @see #getPriority()
      * @see #setCurrent(ServiceProvider)
      */
-    public static final ServiceProvider current() {
+    public static ServiceProvider current() {
         ServiceProvider[] p = getProviders();
         if (p.length != 0) {
             return p[0];
@@ -218,7 +214,7 @@ public abstract class ServiceProvider {
 
                 // Keep the log inside the synchronized block for making sure that the order
                 // or logging messages matches the order in which ServiceProviders were set.
-                Logger.getLogger("javax.measure.spi").log(Level.CONFIG,
+                System.getLogger("javax.measure.spi").log(System.Logger.Level.DEBUG,
                         (old == null) ? "Measurement ServiceProvider set to {0}" : "Measurement ServiceProvider replaced by {0}",
                         provider.getClass().getName());
             }

--- a/src/main/jdk9/module-info.java
+++ b/src/main/jdk9/module-info.java
@@ -32,8 +32,7 @@ module java.measure {
     exports javax.measure.format;
     exports javax.measure.quantity;
     exports javax.measure.spi;
-    requires java.base;
-    requires java.logging;
+
     uses javax.measure.format.QuantityFormat;
     uses javax.measure.format.UnitFormat;
     uses javax.measure.spi.FormatService;


### PR DESCRIPTION
This configuration requires Java 9 for building the Unit-API, however the compilation result is executable on JDK8. This is possible thanks to the new `javac` `release` option provided since JDK9.

The base version is JDK8 and the multi-version JAR file add a JDK9 version. This allow us to break the dependency to `java.util.logging` on JDK 9.

There is no need for Maven toolchain - it became obsolete since the new `release` option in Java 9.
Consequently the `<jdkToolchain>` configuration in the `pom.xml` has been removed. Other changes are:

* Execution of `jacoco-maven-plugin` has been removed since it is currently incompatible with multi-releases JAR file (anyway, it seems to me that test coverage applies to implementations rather than API).
* The `generate-module-info` goal of `moditect-maven-plugin` has been removed since we provide the `module-info` ourselves.

This commit does not yet address https://github.com/unitsofmeasurement/unit-api/issues/124. It addresses only https://github.com/unitsofmeasurement/unit-api/issues/113.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/unit-api/128)
<!-- Reviewable:end -->
