### PR TITLE
Added IntelliJ related files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,10 @@
 /.project
 /.settings
 /bin/
+
+# IntelliJ #
+.idea/
+*.iml
+
+# OS Files #
+.DS_Store


### PR DESCRIPTION
Hey,

By the time I imported the project to my IntelliJ, I've seen something like that:

![screenshot 2018-10-22 at 13 28 46](https://user-images.githubusercontent.com/5684688/47290173-871c7a00-d5fe-11e8-9a8a-03fdd428c2c4.png)

So, I thought about impoving our `.gitignore` a bit :) .

Regards,
TB

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/unit-api/132)
<!-- Reviewable:end -->
