### PR TITLE
Added missing @since 2.0 annotations

### DIFF
--- a/src/main/java/javax/measure/format/UnitFormat.java
+++ b/src/main/java/javax/measure/format/UnitFormat.java
@@ -124,6 +124,7 @@ public interface UnitFormat {
      * @return the unit parsed from the specified character sub-sequence.
      * @throws IllegalArgumentException
      *           if any problem occurs while parsing the specified character sequence (e.g. illegal syntax).
+     * @since 2.0
      */
     Unit<?> parse(CharSequence csq, ParsePosition cursor) throws IllegalArgumentException, MeasurementParseException;
 

--- a/src/main/java/javax/measure/spi/SystemOfUnits.java
+++ b/src/main/java/javax/measure/spi/SystemOfUnits.java
@@ -73,6 +73,7 @@ public interface SystemOfUnits {
      * @param string
      *          the string representation of a unit, not {@code null}.
      * @return the unit with the given string representation.
+     * @since 2.0
      */
     Unit<?> getUnit(String string);
 


### PR DESCRIPTION
Hey,

I've gone through each single file three times and I think we are now good to go with #127 . Hopefully I didn't miss anything.

I didn't take any look at types marked as deprecated (i.e. `UnitFormatService`, `ParserException`), given that our intention is to either merge them with a different type or to completely remove them in the future.

Regards,
TB

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/unit-api/134)
<!-- Reviewable:end -->
