### PR TITLE
110: added javadoc.io badge again

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 unit-api
 ========
 [![Maven metadata URI](https://img.shields.io/maven-metadata/v/http/central.maven.org/maven2/javax/measure/unit-api/maven-metadata.xml.svg)](https://search.maven.org/search?q=a:unit-api)
+[![Javadocs](https://www.javadoc.io/badge/javax.measure/unit-api.svg)](https://www.javadoc.io/doc/javax.measure/unit-api)
 [![CircleCI](https://circleci.com/gh/unitsofmeasurement/unit-api/tree/master.svg?style=svg)](https://circleci.com/gh/unitsofmeasurement/unit-api/tree/master)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/84af6bb532464d4ba65e17625ecdd0d6)](https://www.codacy.com/app/unitsofmeasurement/unit-api?utm_source=github.com&utm_medium=referral&utm_content=unitsofmeasurement/unit-api&utm_campaign=badger)
 [![Coverage Status](https://coveralls.io/repos/github/unitsofmeasurement/unit-api/badge.svg)](https://coveralls.io/github/unitsofmeasurement/unit-api)


### PR DESCRIPTION
I think we can now have a decent `javadoc.io` badge back to our README again :-) 
![screenshot 2018-12-30 at 23 59 27](https://user-images.githubusercontent.com/5684688/50552257-7851e380-0c8f-11e9-9e59-d4461d0e602c.png)

Resolves #110

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/unit-api/156)
<!-- Reviewable:end -->
