### PR TITLE
36: delete optional-restrictions references

### DIFF
--- a/src/main/java/javax/measure/Quantity.java
+++ b/src/main/java/javax/measure/Quantity.java
@@ -139,7 +139,6 @@ public interface Quantity<Q extends Quantity<Q>> {
      * @throws ClassCastException
      *             if the type of an element in the specified operation is
      *             incompatible with this quantity
-     *             (<a href="#optional-restrictions">optional</a>)
      *
      * @param divisor
      *            the {@code Quantity} divisor.
@@ -171,7 +170,6 @@ public interface Quantity<Q extends Quantity<Q>> {
      * @throws ClassCastException
      *             if the type of an element in the specified operation is
      *             incompatible with this quantity
-     *             (<a href="#optional-restrictions">optional</a>)
      *
      * @param multiplicand
      *            the {@code Quantity} multiplicand.


### PR DESCRIPTION
As mentioned in #36 , there are currently no `optional-restrictions` references in our javadocs, so, deleting these references for now until we have something more concrete (and of course, in order to close one more issue 😃 )

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/unit-api/158)
<!-- Reviewable:end -->
