### PR TITLE
161: Fix Jacoco report issue (empty CSV, XML)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -412,6 +412,11 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco.plugin.version}</version>
+                <configuration>
+                  <excludes>
+                    <exclude>META-INF/**</exclude>
+                  </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <id>pre-unit-test</id>


### PR DESCRIPTION
In order to avoid the maven error during JaCoCo report generation, the META-INF contents is excluded from Jacoco analysis.
With that, when created, Jacoco CSV, XML and HTML reports are complete. Without, HTML report is complete, XML and CSV are empty.