### PR TITLE
178 & 179: adjust ParsePosition description

### DIFF
--- a/src/main/java/javax/measure/format/QuantityFormat.java
+++ b/src/main/java/javax/measure/format/QuantityFormat.java
@@ -75,21 +75,20 @@ public interface QuantityFormat {
 
     /**
      * Parses a portion of the specified {@code CharSequence} from the specified position to produce a {@link Quantity}.
-     * If parsing succeeds, then the index of the {@code cursor} argument is updated to the index after the last character used.
+     * If parsing succeeds, then the index of the {@code pos} argument is updated to the index after the last character used.
      *
      * @param csq
      *          the {@code CharSequence} to parse.
-     * @param cursor
-     *          the cursor holding the current parsing index.
+     * @param pos
+     *          a ParsePosition object holding the current parsing index and error parsing index information as described above.
      * @return the quantity parsed from the specified character sub-sequence.
      * @throws IllegalArgumentException
      *           if any problem occurs while parsing the specified character sequence (e.g. illegal syntax).
      */
-    public Quantity<?> parse(CharSequence csq, ParsePosition cursor) throws IllegalArgumentException, MeasurementParseException;
+    public Quantity<?> parse(CharSequence csq, ParsePosition pos) throws IllegalArgumentException, MeasurementParseException;
 
     /**
      * Parses a portion of the specified {@code CharSequence} from the specified position to produce a {@link Quantity}.
-     * If parsing succeeds, then the index of the {@code cursor} argument is updated to the index after the last character used.
      *
      * @param csq
      *          the {@code CharSequence} to parse.

--- a/src/main/java/javax/measure/format/UnitFormat.java
+++ b/src/main/java/javax/measure/format/UnitFormat.java
@@ -114,19 +114,19 @@ public interface UnitFormat {
     }
 
     /**
-     * Parses a portion of the specified <code>CharSequence</code> from the specified position to produce a {@link Unit}. If parsing succeeds, then
-     * the index of the <code>cursor</code> argument is updated to the index after the last character used.
+     * Parses a portion of the specified <code>CharSequence</code> from the specified position to produce a {@link Unit}.
+     * If parsing succeeds, then the index of the <code>pos</code> argument is updated to the index after the last character used.
      *
      * @param csq
      *            the <code>CharSequence</code> to parse.
-     * @param cursor
-     *            the cursor holding the current parsing index.
+     * @param pos
+     *            a ParsePosition object holding the current parsing index and error parsing index information as described above.
      * @return the unit parsed from the specified character sub-sequence.
      * @throws IllegalArgumentException
      *             if any problem occurs while parsing the specified character sequence (e.g. illegal syntax).
      * @since 2.0
      */
-    Unit<?> parse(CharSequence csq, ParsePosition cursor) throws IllegalArgumentException, MeasurementParseException;
+    Unit<?> parse(CharSequence csq, ParsePosition pos) throws IllegalArgumentException, MeasurementParseException;
 
     /**
      * Parses the text into an instance of {@link Unit}.

--- a/src/test/java/javax/measure/test/format/DefaultTestQuantityFormat.java
+++ b/src/test/java/javax/measure/test/format/DefaultTestQuantityFormat.java
@@ -68,8 +68,8 @@ class DefaultTestQuantityFormat extends TestQuantityFormat {
 
     @SuppressWarnings("unchecked")
     @Override
-    public Quantity<?> parse(CharSequence csq, ParsePosition cursor) throws MeasurementParseException {
-        int startDecimal = cursor.getIndex();
+    public Quantity<?> parse(CharSequence csq, ParsePosition pos) throws MeasurementParseException {
+        int startDecimal = pos.getIndex();
         while ((startDecimal < csq.length()) && Character.isWhitespace(csq.charAt(startDecimal))) {
             startDecimal++;
         }
@@ -78,7 +78,7 @@ class DefaultTestQuantityFormat extends TestQuantityFormat {
             endDecimal++;
         }
         BigDecimal decimal = new BigDecimal(csq.subSequence(startDecimal, endDecimal).toString());
-        cursor.setIndex(endDecimal + 1);
+        pos.setIndex(endDecimal + 1);
         Unit unit = SimpleTestUnitFormat.getInstance().parse(csq);
         return TestQuantities.getQuantity(decimal, unit);
     }
@@ -86,7 +86,7 @@ class DefaultTestQuantityFormat extends TestQuantityFormat {
     @SuppressWarnings("unchecked")
     @Override
     public Quantity<?> parse(CharSequence csq, int index) throws MeasurementParseException {
-        int startDecimal = index; // cursor.getIndex();
+        int startDecimal = index;
         while ((startDecimal < csq.length()) && Character.isWhitespace(csq.charAt(startDecimal))) {
             startDecimal++;
         }

--- a/src/test/java/javax/measure/test/format/TestUnitFormat.java
+++ b/src/test/java/javax/measure/test/format/TestUnitFormat.java
@@ -94,7 +94,7 @@ abstract class TestUnitFormat implements UnitFormat {
 
     protected Unit<?> parse(CharSequence csq, int index) throws MeasurementParseException {
         // Parsing reads the whole character sequence from the parse position.
-        int start = index; // cursor != null ? cursor.getIndex() : 0;
+        int start = index;
         int end = csq.length();
         if (end <= start) {
             return TestUnit.ONE;
@@ -126,6 +126,8 @@ abstract class TestUnitFormat implements UnitFormat {
      *
      * @param csq
      *          the <code>CharSequence</code> to parse.
+     * @param pos
+     *          a ParsePosition object holding the current parsing index and error parsing index information as described above.
      * @return the unit parsed from the specified character sub-sequence.
      * @throws MeasurementParseException
      *           if any problem occurs while parsing the specified character sequence (e.g. illegal syntax).


### PR DESCRIPTION
I took the liberty to name it after the [official docs](https://docs.oracle.com/javase/7/docs/api/java/text/Format.html#parseObject(java.lang.String,%20java.text.ParsePosition)) .

In addition, I fixed some minor things where needed. Hope it doesn't create any conflict (in terms of approach) to what is asked in #178 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/unit-api/180)
<!-- Reviewable:end -->
