### PR TITLE
Remove Todo comments exist in pom.xml file while the related issues are already fixed.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -462,9 +462,6 @@
 									destdir="${project.build.directory}/classes/META-INF/versions/${jdkOptionalVersion}"
 									srcdir="${project.basedir}/src/main/jdk${jdkOptionalVersion}"
 									includeAntRuntime="false">
-
-									<!-- TODO: use release attribute instead after next plugin release. 
-										https://issues.apache.org/jira/browse/MANTRUN-214 -->
 									<compilerarg
 										line="--release=${jdkOptionalVersion} --patch-module java.measure=${project.build.directory}/classes" />
 								</javac>
@@ -856,9 +853,6 @@
 											destdir="${project.build.directory}/classes/META-INF/versions/${jdkOptionalVersion}"
 											srcdir="${project.basedir}/src/etc/modules/core/jdk${jdkOptionalVersion}"
 											includeAntRuntime="false">
-
-											<!-- TODO: use release attribute instead after next plugin release. 
-												https://issues.apache.org/jira/browse/MANTRUN-214 -->
 											<compilerarg
 												line="--release=${jdkOptionalVersion} --patch-module java.measure.base=${project.build.directory}/classes" />
 										</javac>


### PR DESCRIPTION
I think the fix of https://issues.apache.org/jira/browse/MANTRUN-214 had been already applied to the associated part, but the comments still exist. The two comments could be removed.

Comment 1:
https://github.com/unitsofmeasurement/unit-api/blob/99737c2f555baf254abfe4147a34612714b13bb2/pom.xml#L466-L467

Comment 2:
https://github.com/unitsofmeasurement/unit-api/blob/99737c2f555baf254abfe4147a34612714b13bb2/pom.xml#L860-L861

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/unit-api/208)
<!-- Reviewable:end -->
