### PR TITLE
Documentation fixes in javadoc

### DIFF
--- a/src/main/java/javax/measure/Unit.java
+++ b/src/main/java/javax/measure/Unit.java
@@ -151,21 +151,26 @@ public interface Unit<Q extends Quantity<Q>> {
      * @see #getDimension()
      */
     boolean isCompatible(Unit<?> that);
-    
-	/**
-	 * Compares two instances of {@code Unit<Q>}, doing the conversion of unit if necessary.
-	 * Unlike {@link #isCompatible(Unit)} an equivalence check requires both units to be strictly type-compatible, 
-	 * because it makes no sense to compare e.g. {@code gram} and {@code mm} for equivalence. While the compatibility check also works across different quantity types.     
-	 *
-	 * @param that the {@code Unit<Q>} to be compared with this instance.
-	 * @return {@code true} if {@code that \u2261 this}.
-	 * @throws NullPointerException if the unit is null
-	 * 
-	 * @see <a href= "https://dictionary.cambridge.org/dictionary/english/equivalent">Cambridge Dictionary: equivalent</a>
-	 * @see <a href= "https://www.lexico.com/en/definition/equivalent">LEXICO: equivalent</a>
-	 * @since 2.1
-	 */
-	boolean isEquivalentTo(Unit<Q> that);
+
+    /**
+     * Indicates if this unit represents the same quantity than the given unit, ignoring name and symbols.
+     * Two units are equivalent if the {@linkplain #getConverterTo(Unit) conversion} between them is identity.
+     *
+     * <p>
+     * Unlike {@link #isCompatible(Unit)} an equivalence check requires both units to be strictly type-compatible,
+     * because it makes no sense to compare e.g. {@code gram} and {@code mm} for equivalence.
+     * By contrast, the compatibility check can works across different quantity types.
+     * </p>
+     *
+     * @param that the {@code Unit<Q>} to be compared with this instance.
+     * @return {@code true} if {@code that \u2261 this}.
+     * @throws NullPointerException if the unit is null
+     *
+     * @see <a href= "https://dictionary.cambridge.org/dictionary/english/equivalent">Cambridge Dictionary: equivalent</a>
+     * @see <a href= "https://www.lexico.com/en/definition/equivalent">LEXICO: equivalent</a>
+     * @since 2.1
+     */
+    boolean isEquivalentTo(Unit<Q> that);
 
     /**
      * Casts this unit to a parameterized unit of specified nature or throw a {@code ClassCastException} if the dimension of the specified quantity and
@@ -265,7 +270,7 @@ public interface Unit<Q extends Quantity<Q>> {
      * @since 2.0
      */
     Unit<Q> shift(Number offset);
-    
+
     /**
      * Returns the result of setting the origin of the scale of measurement to the given value. The returned unit is convertible with all units that are
      * convertible with this unit. For example the following code:<br>
@@ -298,7 +303,7 @@ public interface Unit<Q extends Quantity<Q>> {
      * @since 2.0
      */
     Unit<Q> multiply(Number multiplier);
-    
+
     /**
      * Returns the result of multiplying this unit by the specified factor. For example:<br>
      *
@@ -343,7 +348,7 @@ public interface Unit<Q extends Quantity<Q>> {
      * @since 2.0
      */
     Unit<Q> divide(Number divisor);
-    
+
     /**
      * Returns the result of dividing this unit by an approximate divisor. For example:<br>
      *

--- a/src/main/java/javax/measure/format/QuantityFormat.java
+++ b/src/main/java/javax/measure/format/QuantityFormat.java
@@ -39,7 +39,7 @@ import javax.measure.Quantity;
  *
  * <dl>
  * <dt><span class="strong"><a id="synchronization">Synchronization</a></span></dt>
- * </dl> 
+ * </dl>
  * Instances of this class are not required to be thread-safe. It is recommended to use separate format instances for each thread. If multiple threads
  * access a format concurrently, it must be synchronized externally.
  *
@@ -84,18 +84,22 @@ public interface QuantityFormat {
      * @param pos
      *          a ParsePosition object holding the current parsing index and error parsing index information as described above.
      * @return the quantity parsed from the specified character sub-sequence.
-     * @throws IllegalArgumentException
+     * @throws MeasurementParseException
      *           if any problem occurs while parsing the specified character sequence (e.g. illegal syntax).
      */
-    public Quantity<?> parse(CharSequence csq, ParsePosition pos) throws IllegalArgumentException, MeasurementParseException;
+    public Quantity<?> parse(CharSequence csq, ParsePosition pos) throws MeasurementParseException;
 
     /**
-     * Parses a portion of the specified {@code CharSequence} from the specified position to produce a {@link Quantity}.
+     * Parses the specified {@code CharSequence} to produce a {@link Quantity}.
+     * <p>
+     * The parse must complete normally and parse the entire text. If the parse completes without reading the entire length of the text, an exception
+     * is thrown. If any other problem occurs during parsing, an exception is thrown.
+     * <p>
      *
      * @param csq
      *          the {@code CharSequence} to parse.
      * @return the quantity parsed from the specified character sub-sequence.
-     * @throws IllegalArgumentException
+     * @throws MeasurementParseException
      *           if any problem occurs while parsing the specified character sequence (e.g. illegal syntax).
      */
     public Quantity<?> parse(CharSequence csq) throws MeasurementParseException;

--- a/src/main/java/javax/measure/format/UnitFormat.java
+++ b/src/main/java/javax/measure/format/UnitFormat.java
@@ -39,7 +39,7 @@ import javax.measure.Unit;
  *
  * <dl>
  * <dt><span class="strong"><a id="synchronization">Synchronization</a></span></dt>
- * </dl> 
+ * </dl>
  * <p>
  * Instances of this class are not required to be thread-safe. It is recommended to use separate format instances for each thread. If multiple threads
  * access a format concurrently, it must be synchronized externally.
@@ -124,11 +124,11 @@ public interface UnitFormat {
      * @param pos
      *            a ParsePosition object holding the current parsing index and error parsing index information as described above.
      * @return the unit parsed from the specified character sub-sequence.
-     * @throws IllegalArgumentException
+     * @throws MeasurementParseException
      *             if any problem occurs while parsing the specified character sequence (e.g. illegal syntax).
      * @since 2.0
      */
-    Unit<?> parse(CharSequence csq, ParsePosition pos) throws IllegalArgumentException, MeasurementParseException;
+    Unit<?> parse(CharSequence csq, ParsePosition pos) throws MeasurementParseException;
 
     /**
      * Parses the text into an instance of {@link Unit}.


### PR DESCRIPTION
* Parse methods throw `MeasurementParseException`.
* Clarification in `Unit.isEquivalentTo(Unit)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/unit-api/240)
<!-- Reviewable:end -->
