### PR TITLE
Refactor the handling of JSR-330, JSR-250 and Jakarta annotations in `ServiceProvider`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,10 +70,11 @@
 
 		<!-- Plugins -->
 		<github.maven.version>0.12</github.maven.version>
-		<github.global.server>github</github.global.server>	
+		<github.global.server>github</github.global.server>
 		<license-maven.version>4.1</license-maven.version>
 		<maven.surefire-report.version>2.22.2</maven.surefire-report.version>
         <junit.jupiter.version>5.7.2</junit.jupiter.version>
+        <jakarta.inject.version>2.0.1</jakarta.inject.version>
         <spotbugs-maven.version>4.0.4</spotbugs-maven.version>
 		<!--Exclude the files here -->
 		<sonar.exclusions>src/main/java/javax/measure/BinaryPrefix.java,src/main/java/javax/measure/MetricPrefix.java</sonar.exclusions>
@@ -376,7 +377,7 @@
 					<version>0.5.2</version>
 				</plugin>
 
-				<!--This plugin's configuration is used to store Eclipse m2e settings 
+				<!--This plugin's configuration is used to store Eclipse m2e settings
 					only. It has no influence on the Maven build itself. -->
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>
@@ -475,7 +476,7 @@
 			<!-- Coverage -->
 			<plugin>
 				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>				
+				<artifactId>jacoco-maven-plugin</artifactId>
 				<configuration>
 					<excludes>
 						<exclude>META-INF/versions/**</exclude>
@@ -563,14 +564,14 @@
 				<configuration>
 				    <!-- Workaround for https://github.com/unitsofmeasurement/unit-api/issues/220 -->
                     <source>8</source>
-                </configuration>                
-				<!-- 
+                </configuration>
+				<!--
 				<configuration>
 				    <sourcepath>src/main/java;src/main/jdk9</sourcepath>
 					<detectLinks>true</detectLinks>
 					<keywords>true</keywords>
 					<linksource>true</linksource>
-					<failOnError>false</failOnError>					
+					<failOnError>false</failOnError>
 					<verbose>true</verbose>
                     <tags>
                         <tag>
@@ -612,7 +613,7 @@
 						<manifestEntries>
 							<Specification-Title>${project.name}</Specification-Title>
 							<Specification-Version>${project.version}</Specification-Version>
-							<Specification-Vendor>${project.organization.name}</Specification-Vendor>							
+							<Specification-Vendor>${project.organization.name}</Specification-Vendor>
 							<Automatic-Module-Name>java.measure</Automatic-Module-Name>
 							<Multi-Release>true</Multi-Release>
 						</manifestEntries>
@@ -687,12 +688,12 @@
 						</excludes>
 						<headerDefinitions>
 							<headerDefinition>src/main/config/headers.xml</headerDefinition>
-						</headerDefinitions>			
+						</headerDefinitions>
 					</licenseSet>
 	            </licenseSets>
                 <mapping>
                     <java>JAVA_STYLE</java>
-                </mapping>  
+                </mapping>
             </configuration>
 			</plugin>
 
@@ -792,11 +793,11 @@
 	</reporting>
 
 	<!-- Deployment to public servers -->
-	<distributionManagement>	
+	<distributionManagement>
         <repository>
             <id>ossrh</id>
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>  
+        </repository>
 		<snapshotRepository>
             <id>ossrh</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
@@ -820,6 +821,12 @@
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
 			<version>${junit.jupiter.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.inject</groupId>
+			<artifactId>jakarta.inject-api</artifactId>
+			<version>${jakarta.inject.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -903,7 +910,7 @@
 			<!-- This profile builds (optional) format elements into separate JAR files -->
 			<build>
 				<plugins>
-				    <!-- 
+				    <!--
 				    <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-antrun-plugin</artifactId>
@@ -931,7 +938,7 @@
                         </executions>
                     </plugin>
                     -->
-                    
+
 					<plugin>
 						<artifactId>maven-jar-plugin</artifactId>
 						<version>${maven.jar.version}</version>
@@ -1131,7 +1138,7 @@
                 <jdkOptionalVersion>9</jdkOptionalVersion>
                 <project.build.javaVersion>${jdkVersion}</project.build.javaVersion>
                 <maven.compile.targetLevel>${jdkVersion}</maven.compile.targetLevel>
-                <maven.compile.sourceLevel>${jdkVersion}</maven.compile.sourceLevel>				
+                <maven.compile.sourceLevel>${jdkVersion}</maven.compile.sourceLevel>
 			</properties>
 		</profile>
 	</profiles>

--- a/src/main/java/javax/measure/spi/ServiceProvider.java
+++ b/src/main/java/javax/measure/spi/ServiceProvider.java
@@ -156,16 +156,28 @@ public abstract class ServiceProvider {
         private final String toSearch;
 
         /**
-         * The {@code value()} method in the {@value #NAMED_ANNOTATION} and {@value #PRIORITY_ANNOTATION} annotations,
-         * or {@code null} if those classes are not on the classpath.
+         * The {@code value()} method in the {@value #NAMED_ANNOTATION} annotation,
+         * or {@code null} if that class is not on the classpath.
          */
-        private final Method nameGetter, priorityGetter;
+        private final Method nameGetter;
 
         /**
-         * The {@code value()} method in the {@value #LEGACY_NAMED_ANNOTATION} and {@value #LEGACY_PRIORITY_ANNOTATION} annotations,
-         * or {@code null} if those classes are not on the classpath.
+         * The {@code value()} method in the {@value #PRIORITY_ANNOTATION} annotation,
+         * or {@code null} if that class is not on the classpath.
          */
-        private final Method legacyNameGetter, legacyPriorityGetter;
+        private final Method priorityGetter;
+
+        /**
+         * The {@code value()} method in the {@value #LEGACY_NAMED_ANNOTATION} annotation,
+         * or {@code null} if that class is not on the classpath.
+         */
+        private final Method legacyNameGetter;
+
+        /**
+         * The {@code value()} method in the {@value #LEGACY_PRIORITY_ANNOTATION} annotation,
+         * or {@code null} if that class is not on the classpath.
+         */
+        private final Method legacyPriorityGetter;
 
         /**
          * Creates a new filter and comparator for a stream of service providers.

--- a/src/main/java/javax/measure/spi/ServiceProvider.java
+++ b/src/main/java/javax/measure/spi/ServiceProvider.java
@@ -66,26 +66,26 @@ public abstract class ServiceProvider {
      * Class name of JSR-330 annotation for naming a service provider.
      * We use reflection for keeping JSR-330 an optional dependency.
      */
-    private static final String NAMED_ANNOTATION = "javax.inject.Named";
+    private static final String LEGACY_NAMED_ANNOTATION = "javax.inject.Named";
 
     /**
      * Class name of JSR-250 annotation for assigning a priority level to a service provider.
      * We use reflection for keeping JSR-250 an optional dependency.
      */
-    private static final String PRIORITY_ANNOTATION = "javax.annotation.Priority";
+    private static final String LEGACY_PRIORITY_ANNOTATION = "javax.annotation.Priority";
 
     /**
      * Class name of Jakarta Dependency Injection annotation for naming a service provider.
      * We use reflection for keeping Jakata Injection an optional dependency.
      */
-    private static final String JAKARTA_NAMED_ANNOTATION = "jakarta.inject.Named";
+    private static final String NAMED_ANNOTATION = "jakarta.inject.Named";
 
     /**
      * Class name of Jakarta Common Annotation for assigning a priority level to a service provider.
      * We use reflection for keeping Jakarta Annotations an optional dependency.
      */
-    private static final String JAKARTA_PRIORITY_ANNOTATION = "jakarta.annotation.Priority";
-    
+    private static final String PRIORITY_ANNOTATION = "jakarta.annotation.Priority";
+
     /**
      * The current service provider, or {@code null} if not yet determined.
      *
@@ -106,7 +106,8 @@ public abstract class ServiceProvider {
      * Allows to define a priority for a registered {@code ServiceProvider} instance.
      * When multiple providers are registered in the system, the provider with the highest priority value is taken.
      *
-     * <p>If the {@value #PRIORITY_ANNOTATION} annotation (from JSR-250) or {@value #JAKARTA_PRIORITY_ANNOTATION} annotation (from Jakarta Annotations) is present on the {@code ServiceProvider}
+     * <p>If the {@value #PRIORITY_ANNOTATION} annotation (from Jakarta Annotations)
+     * or {@value #LEGACY_PRIORITY_ANNOTATION} annotation (from JSR-250) is present on the {@code ServiceProvider}
      * implementation class, then that annotation (first if both were present) is taken and this {@code getPriority()} method is ignored.
      * Otherwise – if a {@code Priority} annotation is absent – this method is used as a fallback.</p>
      *
@@ -155,22 +156,16 @@ public abstract class ServiceProvider {
         private final String toSearch;
 
         /**
-         * Class of the {@value #NAMED_ANNOTATION} and {@value #PRIORITY_ANNOTATION} annotations to search,
+         * The {@code value()} method in the {@value #NAMED_ANNOTATION} and {@value #PRIORITY_ANNOTATION} annotations,
          * or {@code null} if those classes are not on the classpath.
          */
-        private Class<? extends Annotation> namedAnnotation, priorityAnnotation;
-        
-        /**
-         * Class of the {@value #JAKARTA_NAMED_ANNOTATION} and {@value #JAKARTA_PRIORITY_ANNOTATION} annotations to search,
-         * or {@code null} if those classes are not on the classpath.
-         */
-        private Class<? extends Annotation> jakartaNamedAnnotation, jakartaPriorityAnnotation;
+        private final Method nameGetter, priorityGetter;
 
         /**
-         * The {@code value()} method in the {@code *Annotation} class,
+         * The {@code value()} method in the {@value #LEGACY_NAMED_ANNOTATION} and {@value #LEGACY_PRIORITY_ANNOTATION} annotations,
          * or {@code null} if those classes are not on the classpath.
          */
-        private Method nameGetter, priorityGetter;
+        private final Method legacyNameGetter, legacyPriorityGetter;
 
         /**
          * Creates a new filter and comparator for a stream of service providers.
@@ -180,31 +175,15 @@ public abstract class ServiceProvider {
         Selector(String name) {
             toSearch = name;
             try {
-                if (name != null) try {
-                    namedAnnotation = Class.forName(NAMED_ANNOTATION).asSubclass(Annotation.class);
-                    nameGetter = namedAnnotation.getMethod("value", (Class[]) null);
-                } catch (ClassNotFoundException e) {
-                    // Ignore since JSR-330 is an optional dependency.
+                if (name != null) {
+                    nameGetter       = getValueMethod(NAMED_ANNOTATION);
+                    legacyNameGetter = getValueMethod(LEGACY_NAMED_ANNOTATION);
+                } else {
+                    nameGetter       = null;
+                    legacyNameGetter = null;
                 }
-                if (nameGetter == null) try { // if nameGetter has not been set already try Jakarta Injection 
-                	jakartaNamedAnnotation = Class.forName(JAKARTA_NAMED_ANNOTATION).asSubclass(Annotation.class);
-                    nameGetter = jakartaNamedAnnotation.getMethod("value", (Class[]) null);
-                } catch (ClassNotFoundException e) {
-                    // Ignore since Jakarta Injection is an optional dependency.
-                }
-                
-                try {
-                    priorityAnnotation = Class.forName(PRIORITY_ANNOTATION).asSubclass(Annotation.class);
-                    priorityGetter = priorityAnnotation.getMethod("value", (Class[]) null);
-                } catch (ClassNotFoundException e) {
-                    // Ignore since JSR-250 is an optional dependency.
-                }
-                if (priorityGetter == null) try { // if priorityGetter has not been set already try Jakarta Annotations
-                	jakartaPriorityAnnotation = Class.forName(JAKARTA_PRIORITY_ANNOTATION).asSubclass(Annotation.class);
-                    priorityGetter = jakartaPriorityAnnotation.getMethod("value", (Class[]) null);
-                } catch (ClassNotFoundException e) {
-                    // Ignore since Jakarta Annotations is an optional dependency.
-                }
+                priorityGetter       = getValueMethod(PRIORITY_ANNOTATION);
+                legacyPriorityGetter = getValueMethod(LEGACY_PRIORITY_ANNOTATION);
             } catch (NoSuchMethodException e) {
                 // Should never happen since value() is a standard public method of those annotations.
                 throw new ServiceConfigurationError("Cannot get annotation value", e);
@@ -212,28 +191,57 @@ public abstract class ServiceProvider {
         }
 
         /**
-         * Returns {@code true} if the given service provider has the name we are looking for.
-         * This method shall be invoked only if a non-null name has been specified to the constructor.
-         * This method looks for the {@value #NAMED_ANNOTATION} annotation or {@value #JAKARTA_NAMED_ANNOTATION} annotation, and if none are found fallbacks on
-         * {@link ServiceProvider#toString()}.
+         * Returns the {@code value()} method in the given annotation class.
+         *
+         * @param  classname  name of the class from which to get the {@code value()} method.
+         * @return the {@code value()} method, or {@code null} if the annotation class was not found.
          */
-        @Override
-        public boolean test(ServiceProvider provider) {
-            Object value = null;
-            if (nameGetter != null) {
-                Annotation a = null;
-                if (namedAnnotation != null) { 
-                	a = provider.getClass().getAnnotation(namedAnnotation);
-                } else if (jakartaNamedAnnotation != null) {
-                	a = provider.getClass().getAnnotation(jakartaNamedAnnotation);
-                }
+        private static Method getValueMethod(final String classname) throws NoSuchMethodException {
+            try {
+                return Class.forName(classname).getMethod("value", (Class[]) null);
+            } catch (ClassNotFoundException e) {
+                // Ignore because JSR-330, JSR-250 and Jakarta are optional dependencies.
+                return null;
+            }
+        }
+
+        /**
+         * Invokes the {@code value()} method on the annotation of the given class.
+         * The annotation on which to invoke the method is given by {@link Method#getDeclaringClass()}.
+         *
+         * @param  provider   class of the provider on which to invoke annotation {@code value()}.
+         * @param  getter     the preferred  {@code value()} method to invoke, or {@code null}.
+         * @param  fallback   an alternative {@code value()} method to invoke, or {@code null}.
+         * @return the value, or {@code null} if none.
+         */
+        private static Object getValue(final Class<?> provider, Method getter, Method fallback) {
+            if (getter == null) {
+                getter = fallback;
+                fallback = null;
+            }
+            while (getter != null) {
+                final Annotation a = provider.getAnnotation(getter.getDeclaringClass().asSubclass(Annotation.class));
                 if (a != null) try {
-                    value = nameGetter.invoke(a, (Object[]) null);
+                    return getter.invoke(a, (Object[]) null);
                 } catch (IllegalAccessException | InvocationTargetException e) {
                     // Should never happen since value() is a public method and should not throw exception.
                     throw new ServiceConfigurationError("Cannot get annotation value", e);
                 }
+                getter = fallback;
+                fallback = null;
             }
+            return null;
+        }
+
+        /**
+         * Returns {@code true} if the given service provider has the name we are looking for.
+         * This method shall be invoked only if a non-null name has been specified to the constructor.
+         * This method looks for the {@value #NAMED_ANNOTATION} and {@value #LEGACY_NAMED_ANNOTATION}
+         * annotations in that order, and if none are found fallbacks on {@link ServiceProvider#toString()}.
+         */
+        @Override
+        public boolean test(final ServiceProvider provider) {
+            Object value = getValue(provider.getClass(), nameGetter, legacyNameGetter);
             if (value == null) {
                 value = provider.toString();
             }
@@ -242,23 +250,13 @@ public abstract class ServiceProvider {
 
         /**
          * Returns the priority of the given service provider.
-         * This method looks for the {@value #PRIORITY_ANNOTATION} annotation or {@value #JAKARTA_PRIORITY_ANNOTATION},
-         * and if none are found falls back on {@link ServiceProvider#getPriority()}.
+         * This method looks for the {@value #PRIORITY_ANNOTATION} and {@value #LEGACY_PRIORITY_ANNOTATION}
+         * annotations in that order, and if none are found falls back on {@link ServiceProvider#getPriority()}.
          */
-        private int priority(ServiceProvider provider) {
-            if (priorityGetter != null) {
-                Annotation a = null;
-                if (priorityAnnotation != null) {
-                	a = provider.getClass().getAnnotation(priorityAnnotation);
-                } else if (jakartaPriorityAnnotation != null) {
-                	a = provider.getClass().getAnnotation(jakartaPriorityAnnotation);
-                }
-                if (a != null) try {
-                    return (Integer) priorityGetter.invoke(a, (Object[]) null);
-                } catch (IllegalAccessException | InvocationTargetException e) {
-                    // Should never happen since value() is a public method and should not throw exception.
-                    throw new ServiceConfigurationError("Cannot get annotation value", e);
-                }
+        private int priority(final ServiceProvider provider) {
+            Object value = getValue(provider.getClass(), priorityGetter, legacyPriorityGetter);
+            if (value != null) {
+                return (Integer) value;
             }
             return provider.getPriority();
         }
@@ -328,8 +326,10 @@ setcur: if (first != null) {
     /**
      * Returns the {@link ServiceProvider} with the specified name.
      * The given name must match the name of at least one service provider available in the current thread's
-     * context class loader. The service provider names are the values of {@value #NAMED_ANNOTATION} annotations
-     * when present, or the value of {@link #toString()} method for providers without {@code Named} annotation.
+     * context class loader.
+     * The service provider names are the values of {@value #NAMED_ANNOTATION} (from Jakarta Annotations) or
+     * {@value #LEGACY_NAMED_ANNOTATION} (from JSR-330) annotations when present (first if both were present),
+     * or the value of {@link #toString()} method for providers without {@code Named} annotation.
      *
      * <p>Implementors are encouraged to provide an {@code Named} annotation or to override {@link #toString()}
      * and use a unique enough name, e.g. the class name or other distinct attributes.

--- a/src/main/jdk9/javax/measure/spi/ServiceProvider.java
+++ b/src/main/jdk9/javax/measure/spi/ServiceProvider.java
@@ -54,7 +54,7 @@ import javax.measure.format.UnitFormat;
  * All the methods in this class are safe to use by multiple concurrent threads.
  * </p>
  *
- * @version 2.1, November 16, 2020
+ * @version 2.2, November 16, 2020
  * @author Werner Keil
  * @author Martin Desruisseaux
  * @since 1.0
@@ -64,25 +64,25 @@ public abstract class ServiceProvider {
      * Class name of JSR-330 annotation for naming a service provider.
      * We use reflection for keeping JSR-330 an optional dependency.
      */
-    private static final String NAMED_ANNOTATION = "javax.inject.Named";
+    private static final String LEGACY_NAMED_ANNOTATION = "javax.inject.Named";
 
     /**
      * Class name of JSR-250 annotation for assigning a priority level to a service provider.
      * We use reflection for keeping JSR-250 an optional dependency.
      */
-    private static final String PRIORITY_ANNOTATION = "javax.annotation.Priority";
+    private static final String LEGACY_PRIORITY_ANNOTATION = "javax.annotation.Priority";
 
     /**
      * Class name of Jakarta Dependency Injection annotation for naming a service provider.
      * We use reflection for keeping Jakata Injection an optional dependency.
      */
-    private static final String JAKARTA_NAMED_ANNOTATION = "jakarta.inject.Named";
+    private static final String NAMED_ANNOTATION = "jakarta.inject.Named";
 
     /**
      * Class name of Jakarta Common Annotation for assigning a priority level to a service provider.
      * We use reflection for keeping Jakarta Annotations an optional dependency.
      */
-    private static final String JAKARTA_PRIORITY_ANNOTATION = "jakarta.annotation.Priority";
+    private static final String PRIORITY_ANNOTATION = "jakarta.annotation.Priority";
 
     /**
      * The current service provider, or {@code null} if not yet determined.
@@ -104,7 +104,8 @@ public abstract class ServiceProvider {
      * Allows to define a priority for a registered {@code ServiceProvider} instance.
      * When multiple providers are registered in the system, the provider with the highest priority value is taken.
      *
-     * <p>If the {@value #PRIORITY_ANNOTATION} annotation (from JSR-250) or {@value #JAKARTA_PRIORITY_ANNOTATION} annotation (from Jakarta Annotations) is present on the {@code ServiceProvider}
+     * <p>If the {@value #PRIORITY_ANNOTATION} annotation (from Jakarta Annotations)
+     * or {@value #LEGACY_PRIORITY_ANNOTATION} annotation (from JSR-250) is present on the {@code ServiceProvider}
      * implementation class, then that annotation (first if both were present) is taken and this {@code getPriority()} method is ignored.
      * Otherwise – if a {@code Priority} annotation is absent – this method is used as a fallback.</p>
      *
@@ -153,23 +154,17 @@ public abstract class ServiceProvider {
         private final String toSearch;
 
         /**
-         * Class of the {@value #NAMED_ANNOTATION} and {@value #PRIORITY_ANNOTATION} annotations to search,
+         * The {@code value()} method in the {@value #NAMED_ANNOTATION} and {@value #PRIORITY_ANNOTATION} annotations,
          * or {@code null} if those classes are not on the classpath.
          */
-        private Class<? extends Annotation> namedAnnotation, priorityAnnotation;
-        
-        /**
-         * Class of the {@value #JAKARTA_NAMED_ANNOTATION} and {@value #JAKARTA_PRIORITY_ANNOTATION} annotations to search,
-         * or {@code null} if those classes are not on the classpath.
-         */
-        private Class<? extends Annotation> jakartaNamedAnnotation, jakartaPriorityAnnotation;
+        private final Method nameGetter, priorityGetter;
 
         /**
-         * The {@code value()} method in the {@code *Annotation} class,
+         * The {@code value()} method in the {@value #LEGACY_NAMED_ANNOTATION} and {@value #LEGACY_PRIORITY_ANNOTATION} annotations,
          * or {@code null} if those classes are not on the classpath.
          */
-        private Method nameGetter, priorityGetter;
-        
+        private final Method legacyNameGetter, legacyPriorityGetter;
+
         /**
          * Creates a new filter and comparator for a stream of service providers.
          *
@@ -178,31 +173,15 @@ public abstract class ServiceProvider {
         Selector(String name) {
             toSearch = name;
             try {
-                if (name != null) try {
-                    namedAnnotation = Class.forName(NAMED_ANNOTATION).asSubclass(Annotation.class);
-                    nameGetter = namedAnnotation.getMethod("value", (Class[]) null);
-                } catch (ClassNotFoundException e) {
-                    // Ignore since JSR-330 is an optional dependency.
+                if (name != null) {
+                    nameGetter       = getValueMethod(NAMED_ANNOTATION);
+                    legacyNameGetter = getValueMethod(LEGACY_NAMED_ANNOTATION);
+                } else {
+                    nameGetter       = null;
+                    legacyNameGetter = null;
                 }
-                if (nameGetter == null) try { // if nameGetter has not been set already try Jakarta Injection 
-                	jakartaNamedAnnotation = Class.forName(JAKARTA_NAMED_ANNOTATION).asSubclass(Annotation.class);
-                    nameGetter = jakartaNamedAnnotation.getMethod("value", (Class[]) null);
-                } catch (ClassNotFoundException e) {
-                    // Ignore since Jakarta Injection is an optional dependency.
-                }
-                
-                try {
-                    priorityAnnotation = Class.forName(PRIORITY_ANNOTATION).asSubclass(Annotation.class);
-                    priorityGetter = priorityAnnotation.getMethod("value", (Class[]) null);
-                } catch (ClassNotFoundException e) {
-                    // Ignore since JSR-250 is an optional dependency.
-                }
-                if (priorityGetter == null) try { // if priorityGetter has not been set already try Jakarta Annotations
-                	jakartaPriorityAnnotation = Class.forName(JAKARTA_PRIORITY_ANNOTATION).asSubclass(Annotation.class);
-                    priorityGetter = jakartaPriorityAnnotation.getMethod("value", (Class[]) null);
-                } catch (ClassNotFoundException e) {
-                    // Ignore since Jakarta Annotations is an optional dependency.
-                }
+                priorityGetter       = getValueMethod(PRIORITY_ANNOTATION);
+                legacyPriorityGetter = getValueMethod(LEGACY_PRIORITY_ANNOTATION);
             } catch (NoSuchMethodException e) {
                 // Should never happen since value() is a standard public method of those annotations.
                 throw new ServiceConfigurationError("Cannot get annotation value", e);
@@ -210,28 +189,57 @@ public abstract class ServiceProvider {
         }
 
         /**
-         * Returns {@code true} if the given service provider has the name we are looking for.
-         * This method shall be invoked only if a non-null name has been specified to the constructor.
-         * This method looks for the {@value #NAMED_ANNOTATION} annotation or {@value #JAKARTA_NAMED_ANNOTATION} annotation, and if none are found fallbacks on
-         * {@link ServiceProvider#toString()}.
+         * Returns the {@code value()} method in the given annotation class.
+         *
+         * @param  classname  name of the class from which to get the {@code value()} method.
+         * @return the {@code value()} method, or {@code null} if the annotation class was not found.
          */
-        @Override
-        public boolean test(ServiceProvider provider) {
-            Object value = null;
-            if (nameGetter != null) {
-                Annotation a = null;
-                if (namedAnnotation != null) { 
-                	a = provider.getClass().getAnnotation(namedAnnotation);
-                } else if (jakartaNamedAnnotation != null) {
-                	a = provider.getClass().getAnnotation(jakartaNamedAnnotation);
-                }
+        private static Method getValueMethod(final String classname) throws NoSuchMethodException {
+            try {
+                return Class.forName(classname).getMethod("value", (Class[]) null);
+            } catch (ClassNotFoundException e) {
+                // Ignore because JSR-330, JSR-250 and Jakarta are optional dependencies.
+                return null;
+            }
+        }
+
+        /**
+         * Invokes the {@code value()} method on the annotation of the given class.
+         * The annotation on which to invoke the method is given by {@link Method#getDeclaringClass()}.
+         *
+         * @param  provider   class of the provider on which to invoke annotation {@code value()}.
+         * @param  getter     the preferred  {@code value()} method to invoke, or {@code null}.
+         * @param  fallback   an alternative {@code value()} method to invoke, or {@code null}.
+         * @return the value, or {@code null} if none.
+         */
+        private static Object getValue(final Class<?> provider, Method getter, Method fallback) {
+            if (getter == null) {
+                getter = fallback;
+                fallback = null;
+            }
+            while (getter != null) {
+                final Annotation a = provider.getAnnotation(getter.getDeclaringClass().asSubclass(Annotation.class));
                 if (a != null) try {
-                    value = nameGetter.invoke(a, (Object[]) null);
+                    return getter.invoke(a, (Object[]) null);
                 } catch (IllegalAccessException | InvocationTargetException e) {
                     // Should never happen since value() is a public method and should not throw exception.
                     throw new ServiceConfigurationError("Cannot get annotation value", e);
                 }
+                getter = fallback;
+                fallback = null;
             }
+            return null;
+        }
+
+        /**
+         * Returns {@code true} if the given service provider has the name we are looking for.
+         * This method shall be invoked only if a non-null name has been specified to the constructor.
+         * This method looks for the {@value #NAMED_ANNOTATION} and {@value #LEGACY_NAMED_ANNOTATION}
+         * annotations in that order, and if none are found fallbacks on {@link ServiceProvider#toString()}.
+         */
+        @Override
+        public boolean test(final ServiceProvider provider) {
+            Object value = getValue(provider.getClass(), nameGetter, legacyNameGetter);
             if (value == null) {
                 value = provider.toString();
             }
@@ -240,23 +248,13 @@ public abstract class ServiceProvider {
 
         /**
          * Returns the priority of the given service provider.
-         * This method looks for the {@value #PRIORITY_ANNOTATION} annotation or {@value #JAKARTA_PRIORITY_ANNOTATION},
-         * and if none are found falls back on {@link ServiceProvider#getPriority()}.
+         * This method looks for the {@value #PRIORITY_ANNOTATION} and {@value #LEGACY_PRIORITY_ANNOTATION}
+         * annotations in that order, and if none are found falls back on {@link ServiceProvider#getPriority()}.
          */
-        private int priority(ServiceProvider provider) {
-            if (priorityGetter != null) {
-                Annotation a = null;
-                if (priorityAnnotation != null) {
-                	a = provider.getClass().getAnnotation(priorityAnnotation);
-                } else if (jakartaPriorityAnnotation != null) {
-                	a = provider.getClass().getAnnotation(jakartaPriorityAnnotation);
-                }
-                if (a != null) try {
-                    return (Integer) priorityGetter.invoke(a, (Object[]) null);
-                } catch (IllegalAccessException | InvocationTargetException e) {
-                    // Should never happen since value() is a public method and should not throw exception.
-                    throw new ServiceConfigurationError("Cannot get annotation value", e);
-                }
+        private int priority(final ServiceProvider provider) {
+            Object value = getValue(provider.getClass(), priorityGetter, legacyPriorityGetter);
+            if (value != null) {
+                return (Integer) value;
             }
             return provider.getPriority();
         }
@@ -326,8 +324,10 @@ setcur: if (first != null) {
     /**
      * Returns the {@link ServiceProvider} with the specified name.
      * The given name must match the name of at least one service provider available in the current thread's
-     * context class loader. The service provider names are the values of {@value #NAMED_ANNOTATION} annotations
-     * when present, or the value of {@link #toString()} method for providers without {@code Named} annotation.
+     * context class loader.
+     * The service provider names are the values of {@value #NAMED_ANNOTATION} (from Jakarta Annotations) or
+     * {@value #LEGACY_NAMED_ANNOTATION} (from JSR-330) annotations when present (first if both were present),
+     * or the value of {@link #toString()} method for providers without {@code Named} annotation.
      *
      * <p>Implementors are encouraged to provide an {@code Named} annotation or to override {@link #toString()}
      * and use a unique enough name, e.g. the class name or other distinct attributes.

--- a/src/main/jdk9/javax/measure/spi/ServiceProvider.java
+++ b/src/main/jdk9/javax/measure/spi/ServiceProvider.java
@@ -155,16 +155,28 @@ public abstract class ServiceProvider {
         private final String toSearch;
 
         /**
-         * The {@code value()} method in the {@value #NAMED_ANNOTATION} and {@value #PRIORITY_ANNOTATION} annotations,
-         * or {@code null} if those classes are not on the classpath.
+         * The {@code value()} method in the {@value #NAMED_ANNOTATION} annotation,
+         * or {@code null} if that class is not on the classpath.
          */
-        private final Method nameGetter, priorityGetter;
+        private final Method nameGetter;
 
         /**
-         * The {@code value()} method in the {@value #LEGACY_NAMED_ANNOTATION} and {@value #LEGACY_PRIORITY_ANNOTATION} annotations,
-         * or {@code null} if those classes are not on the classpath.
+         * The {@code value()} method in the {@value #PRIORITY_ANNOTATION} annotation,
+         * or {@code null} if that class is not on the classpath.
          */
-        private final Method legacyNameGetter, legacyPriorityGetter;
+        private final Method priorityGetter;
+
+        /**
+         * The {@code value()} method in the {@value #LEGACY_NAMED_ANNOTATION} annotation,
+         * or {@code null} if that class is not on the classpath.
+         */
+        private final Method legacyNameGetter;
+
+        /**
+         * The {@code value()} method in the {@value #LEGACY_PRIORITY_ANNOTATION} annotation,
+         * or {@code null} if that class is not on the classpath.
+         */
+        private final Method legacyPriorityGetter;
 
         /**
          * Creates a new filter and comparator for a stream of service providers.

--- a/src/test/java/javax/measure/spi/ServiceProviderTest.java
+++ b/src/test/java/javax/measure/spi/ServiceProviderTest.java
@@ -29,6 +29,7 @@
  */
 package javax.measure.spi;
 
+import jakarta.inject.Named;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -70,7 +71,7 @@ public class ServiceProviderTest {
         assertSame(testProv, ServiceProvider.setCurrent(testProv), "Setting the same ServiceProvider twice should be a no-op.");
         assertSame(testProv, ServiceProvider.current());
         assertArrayEquals(new ServiceProvider[] { testProv }, ServiceProvider.available().toArray());
-        assertNotNull(ServiceProvider.of("TestServiceProvider"));
+        assertNotNull(ServiceProvider.of("Dummy ServiceProvider"));
     }
 
     /**
@@ -145,6 +146,7 @@ public class ServiceProviderTest {
         });
     }
 
+    @Named("Dummy ServiceProvider")     // Intentionally use a name different than "TestServiceProvider".
     private static final class TestServiceProvider extends ServiceProvider {
 
         @Override


### PR DESCRIPTION
Changes in this merge request:

* Allows `javax.inject` and `jakarta.inject` to coexist on the classpath. Before this commit, if both were present on the classpath, then the code checked only `javax.inject` annotations and Jakarta was ignored.
* If both annotations are present on the same class, give precedence to Jakarta. In my understanding, `javax.inject` annotations are deprecated in favour of `jakarta.inject`. See for example [OpenRewrite](https://docs.openrewrite.org/reference/recipes/java/migrate/javaxinjectmigrationtojakartainject).
* Added the use of Jakarta `@Named` annotation in JUnit test, for testing the code path that check annotation values.
* Minor bug fix in the `if (name != null)` check: after the addition of Jakarta annotations, a pair of `{ … }` should have been added for applying the condition to both JSR and Jakarta annotations. Before this commit, the condition applied only to JSR annotations because of missing `{ … }`. The bug was there:

https://github.com/unitsofmeasurement/unit-api/blob/b5ca1576b7df480d7692ea26bbfd9c332945b5c0/src/main/java/javax/measure/spi/ServiceProvider.java#L183

After above changes are applied, the second commit specializes the Java 9 implementation for taking advantage of Java 9 capability to defer the initialization of `ServiceProvider` implementations. The deferred initialization is handled by `ServiceLoader.Provider` (new in Java 9).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/unit-api/242)
<!-- Reviewable:end -->
