### PR TITLE
Remove unused `use` statements

### DIFF
--- a/src/main/jdk9/module-info.java
+++ b/src/main/jdk9/module-info.java
@@ -28,8 +28,6 @@
  * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 module java.measure {
-	requires java.logging;
-
     exports javax.measure;
     exports javax.measure.format;
     exports javax.measure.quantity;

--- a/src/main/jdk9/module-info.java
+++ b/src/main/jdk9/module-info.java
@@ -29,16 +29,11 @@
  */
 module java.measure {
 	requires java.logging;
-	
+
     exports javax.measure;
     exports javax.measure.format;
     exports javax.measure.quantity;
     exports javax.measure.spi;
 
-    uses javax.measure.format.QuantityFormat;
-    uses javax.measure.format.UnitFormat;
-    uses javax.measure.spi.FormatService;
-    uses javax.measure.spi.QuantityFactory;
     uses javax.measure.spi.ServiceProvider;
-    uses javax.measure.spi.SystemOfUnitsService;
 }


### PR DESCRIPTION
We do not need to put a `use` statement in `module-info` for services that the JAR does not use. Omitting services in that file does not block users for using them. They can still use those services by declaring them in their own `module-info` file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/unit-api/247)
<!-- Reviewable:end -->
