### PR TITLE
Reformat root pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -572,41 +572,6 @@
 					https://github.com/unitsofmeasurement/unit-api/issues/220 -->
 					<source>8</source>
 				</configuration>
-				<!--
-				<configuration>
-				<sourcepath>src/main/java;src/main/jdk9</sourcepath>
-				<detectLinks>true</detectLinks>
-					<keywords>true</keywords>
-				<linksource>true</linksource>
-					<failOnError>false</failOnError>
-				<verbose>true</verbose>
-                    <tags>
-                        <tag>
-				<name>apiNote</name>
-                            <placement>a</placement>
-				<head>API Note:</head>
-                        </tag>
-                        <tag>
-				<name>implSpec</name>
-                            <placement>a</placement>
-				<head>Implementation Requirements:</head>
-                        </tag>
-				<tag>
-                            <name>implNote</name>
-				<placement>a</placement>
-                            <head>Implementation
-				Note:</head>
-                        </tag>
-				<tag><name>param</name></tag>
-                        <tag><name>return</name></tag>
-				<tag><name>throws</name></tag>
-                        <tag><name>since</name></tag>
-				<tag><name>version</name></tag>
-				<tag><name>serialData</name></tag>
-                        <tag><name>see</name></tag>
-				</tags>
-				</configuration>
-				 -->
 			</plugin>
 
 			<!-- JAR packaging -->
@@ -936,37 +901,6 @@
 			JAR files -->
 			<build>
 				<plugins>
-					<!--
-				    <plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-antrun-plugin</artifactId>
-                        <executions>
-					<execution>
-                                <phase>prepare-package</phase>
-					<goals>
-                                    <goal>run</goal>
-					</goals>
-                                <configuration>
-					<target>
-                                        <mkdir
-					dir="${project.build.directory}/classes/META-INF/versions/${jdkOptionalVersion}"
-					/>
-                                        <javac
-					destdir="${project.build.directory}/classes/META-INF/versions/${jdkOptionalVersion}"
-					srcdir="${project.basedir}/src/etc/modules/format/jdk${jdkOptionalVersion}"
-					includeAntRuntime="false">
-                                            <compilerarg
-					line="-release=${jdkOptionalVersion} -patch-module
-					java.measure.format=${project.build.directory}/classes" />
-					FIXME double hyphen for -patch-module and -release
-                                        </javac>
-					</target>
-                                </configuration>
-					</execution>
-                        </executions>
-					</plugin>
-                    -->
-
 					<plugin>
 						<artifactId>maven-jar-plugin</artifactId>
 						<version>${maven.jar.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,1112 +1,1103 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<groupId>javax.measure</groupId>
-	<artifactId>unit-api</artifactId>
-	<name>Units of Measurement API</name>
-	<packaging>bundle</packaging>
-	<url>http://unitsofmeasurement.github.io/unit-api/</url>
-	<description>Units of Measurement Standard - This JSR specifies Java
-		packages for modeling and working with measurement values, quantities
-		and their corresponding units.</description>
-	<organization>
-		<name>Jean-Marie Dautelle, Werner Keil, Otavio Santana</name>
-		<url>http://unitsofmeasurement.github.io</url>
-	</organization>
-	<inceptionYear>2014</inceptionYear>
-	<licenses>
-		<license>
-			<name>BSD 3-Clause</name>
-			<url>LICENSE</url>
-			<distribution>manual</distribution>
-		</license>
-	</licenses>
-	<parent>
-		<groupId>tech.uom</groupId>
-		<artifactId>uom-parent</artifactId>
-		<version>2.2-SNAPSHOT</version>
-	</parent>
-	<version>2.2-SNAPSHOT</version>
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>javax.measure</groupId>
+    <artifactId>unit-api</artifactId>
+    <name>Units of Measurement API</name>
+    <packaging>bundle</packaging>
+    <url>http://unitsofmeasurement.github.io/unit-api/</url>
+    <description>Units of Measurement Standard - This JSR specifies Java
+        packages for modeling and working with measurement values, quantities
+        and their corresponding units.</description>
+    <organization>
+        <name>Jean-Marie Dautelle, Werner Keil, Otavio Santana</name>
+        <url>http://unitsofmeasurement.github.io</url>
+    </organization>
+    <inceptionYear>2014</inceptionYear>
+    <licenses>
+        <license>
+            <name>BSD 3-Clause</name>
+            <url>LICENSE</url>
+            <distribution>manual</distribution>
+        </license>
+    </licenses>
+    <parent>
+        <groupId>tech.uom</groupId>
+        <artifactId>uom-parent</artifactId>
+        <version>2.2-SNAPSHOT</version>
+    </parent>
+    <version>2.2-SNAPSHOT</version>
 
-	<!-- Issue managements and mailing lists. -->
-	<issueManagement>
-		<system>GitHub</system>
-		<url>https://github.com/unitsofmeasurement/unit-api/issues</url>
-	</issueManagement>
-	<ciManagement>
-		<system>CircleCI</system>
-		<url>https://circleci.com/gh/unitsofmeasurement/unit-api</url>
-	</ciManagement>
+    <!-- Issue managements and mailing lists. -->
+    <issueManagement>
+        <system>GitHub</system>
+        <url>https://github.com/unitsofmeasurement/unit-api/issues</url>
+    </issueManagement>
+    <ciManagement>
+        <system>CircleCI</system>
+        <url>https://circleci.com/gh/unitsofmeasurement/unit-api</url>
+    </ciManagement>
 
-	<mailingLists>
-		<mailingList>
-			<name>Units-Dev</name>
-			<subscribe>https://groups.google.com/group/units-dev/subscribe</subscribe>
-			<post>units-dev@googlegroups.com</post>
-		</mailingList>
-		<mailingList>
-			<name>Units-Users</name>
-			<subscribe>https://groups.google.com/group/units-users/subscribe</subscribe>
-			<post>units-users@googlegroups.com</post>
-		</mailingList>
-	</mailingLists>
-	<scm>
-		<connection>scm:git:git@github.com:unitsofmeasurement/unit-api.git</connection>
-		<developerConnection>
-			scm:git:git@github.com:unitsofmeasurement/unit-api.git</developerConnection>
-		<url>https://github.com/unitsofmeasurement/unit-api</url>
-	</scm>
+    <mailingLists>
+        <mailingList>
+            <name>Units-Dev</name>
+            <subscribe>https://groups.google.com/group/units-dev/subscribe</subscribe>
+            <post>units-dev@googlegroups.com</post>
+        </mailingList>
+        <mailingList>
+            <name>Units-Users</name>
+            <subscribe>https://groups.google.com/group/units-users/subscribe</subscribe>
+            <post>units-users@googlegroups.com</post>
+        </mailingList>
+    </mailingLists>
+    <scm>
+        <connection>scm:git:git@github.com:unitsofmeasurement/unit-api.git</connection>
+        <developerConnection>
+            scm:git:git@github.com:unitsofmeasurement/unit-api.git</developerConnection>
+        <url>https://github.com/unitsofmeasurement/unit-api</url>
+    </scm>
 
-	<!-- Build Settings -->
-	<properties>
-		<basedir>.</basedir>
-		<sourceEncoding>UTF-8</sourceEncoding> <!-- in Maven 3. -->
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.reporting.outputEncoding>${sourceEncoding}</project.reporting.outputEncoding>
-		<jdkVersion>8</jdkVersion>
-		<jdkOptionalVersion>9</jdkOptionalVersion>
-		<project.build.javaVersion>${jdkVersion}</project.build.javaVersion>
-		<maven.compile.targetLevel>${jdkVersion}</maven.compile.targetLevel>
-		<maven.compile.sourceLevel>${jdkVersion}</maven.compile.sourceLevel>
-		<additionalparam>-Xdoclint:none</additionalparam>
-		<thisYear>2023</thisYear>
+    <!-- Build Settings -->
+    <properties>
+        <basedir>.</basedir>
+        <sourceEncoding>UTF-8</sourceEncoding> <!-- in Maven 3. -->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>${sourceEncoding}</project.reporting.outputEncoding>
+        <jdkVersion>8</jdkVersion>
+        <jdkOptionalVersion>9</jdkOptionalVersion>
+        <project.build.javaVersion>${jdkVersion}</project.build.javaVersion>
+        <maven.compile.targetLevel>${jdkVersion}</maven.compile.targetLevel>
+        <maven.compile.sourceLevel>${jdkVersion}</maven.compile.sourceLevel>
+        <additionalparam>-Xdoclint:none</additionalparam>
+        <thisYear>2023</thisYear>
 
-		<!-- Plugins -->
-		<github.maven.version>0.12</github.maven.version>
-		<github.global.server>github</github.global.server>
-		<license-maven.version>4.2</license-maven.version>
-		<maven.surefire-report.version>2.22.2</maven.surefire-report.version>
-		<junit.jupiter.version>5.9.2</junit.jupiter.version>
-		<jakarta.inject.version>2.0.1</jakarta.inject.version>
-		<spotbugs-maven.version>4.7.3.4</spotbugs-maven.version>
-		<!--Exclude the files here -->
-		<sonar.exclusions>
-			src/main/java/javax/measure/BinaryPrefix.java,src/main/java/javax/measure/MetricPrefix.java</sonar.exclusions>
-	</properties>
+        <!-- Plugins -->
+        <github.maven.version>0.12</github.maven.version>
+        <github.global.server>github</github.global.server>
+        <license-maven.version>4.2</license-maven.version>
+        <maven.surefire-report.version>2.22.2</maven.surefire-report.version>
+        <junit.jupiter.version>5.9.2</junit.jupiter.version>
+        <jakarta.inject.version>2.0.1</jakarta.inject.version>
+        <spotbugs-maven.version>4.7.3.4</spotbugs-maven.version>
+        <!--Exclude the files here -->
+        <sonar.exclusions>
+            src/main/java/javax/measure/BinaryPrefix.java,src/main/java/javax/measure/MetricPrefix.java</sonar.exclusions>
+    </properties>
 
-	<!-- Developers and Contributors -->
-	<developers>
-		<developer>
-			<id>dautelle</id>
-			<name>Jean-Marie Dautelle</name>
-			<email>jean-marie@dautelle.com</email>
-			<organization>Airbus</organization>
-			<organizationUrl>http://www.airbus.com</organizationUrl>
-			<timezone>+1</timezone>
-			<roles>
-				<role>Architect</role>
-				<role>Java Developer</role>
-				<role>Spec Lead</role>
-			</roles>
-		</developer>
-		<developer>
-			<id>keilw</id>
-			<name>Werner Keil</name>
-			<email>werner.keil@gmx.net</email>
-			<organization>Creative Arts &amp; Technologies</organization>
-			<organizationUrl>http://www.catmedia.us</organizationUrl>
-			<timezone>+1</timezone>
-			<roles>
-				<role>Architect</role>
-				<role>Java Developer</role>
-				<role>Spec Lead</role>
-			</roles>
-		</developer>
-		<developer>
-			<id>otaviojava</id>
-			<name>Otávio Gonçalves de Santana</name>
-			<email>otaviopolianasantana@gmail.com</email>
-			<organization>Individual / SouJava</organization>
-			<timezone>-5</timezone>
-			<roles>
-				<role>Expert</role>
-				<role>Java Developer</role>
-				<role>Spec Lead</role>
-			</roles>
-		</developer>
-		<developer>
-			<id>desruisseaux</id>
-			<name>Martin Desruisseaux</name>
-			<email>martin.desruisseaux@geomatys.com</email>
-			<organization>Geomatys</organization>
-			<organizationUrl>http://www.geomatys.com</organizationUrl>
-			<timezone>+1</timezone>
-			<roles>
-				<role>Expert</role>
-				<role>Java Developer</role>
-				<role>Architect</role>
-			</roles>
-		</developer>
-		<developer>
-			<id>thodorisbais</id>
-			<name>Thodoris Bais</name>
-			<email>thodoris.bais@gmail.com</email>
-			<organization>Individual / Utrecht JUG</organization>
-			<timezone>+1</timezone>
-			<roles>
-				<role>Expert</role>
-				<role>Java Developer</role>
-			</roles>
-		</developer>
-		<developer>
-			<id>Daniel-Dos</id>
-			<name>Daniel Dias</name>
-			<email>daniel.dias.analistati@gmail.com</email>
-			<organization>Individual / SouJava</organization>
-			<timezone>-5</timezone>
-			<roles>
-				<role>Expert</role>
-				<role>Java Developer</role>
-			</roles>
-		</developer>
-		<developer>
-			<id>jhg023</id>
-			<name>Jacob Glickman</name>
-			<organization>Individual</organization>
-			<timezone>-4</timezone>
-			<roles>
-				<role>Expert</role>
-				<role>Java Developer</role>
-			</roles>
-		</developer>
-		<developer>
-			<id>magesh678</id>
-			<name>Magesh Kasthuri</name>
-			<organization>Individual</organization>
-			<timezone>+4</timezone>
-			<roles>
-				<role>Expert</role>
-				<role>Java Developer</role>
-			</roles>
-		</developer>
-		<developer>
-			<id>mohalmo</id>
-			<name>Mohammed Al-Moayed</name>
-			<organization>Individual</organization>
-			<timezone>+2</timezone>
-			<roles>
-				<role>Expert</role>
-				<role>Java Developer</role>
-			</roles>
-		</developer>
-	</developers>
-	<contributors>
-		<contributor>
-			<name>Andi Huber</name>
-			<organization>Individual</organization>
-			<timezone>+1</timezone>
-			<roles>
-				<role>Contributor</role>
-			</roles>
-		</contributor>
-		<contributor>
-			<name>Filip Van Laenen</name>
-			<email>fvl@computas.com</email>
-			<organization>Computas</organization>
-			<timezone>+1</timezone>
-			<roles>
-				<role>Contributor</role>
-			</roles>
-		</contributor>
-		<contributor>
-			<name>Mads Opheim</name>
-			<organization>Computas</organization>
-			<timezone>+1</timezone>
-			<roles>
-				<role>Contributor</role>
-			</roles>
-		</contributor>
-		<contributor>
-			<name>Matthijs Thoolen</name>
-			<organization>Utrecht Java User Group</organization>
-			<timezone>+1</timezone>
-			<roles>
-				<role>Contributor</role>
-			</roles>
-		</contributor>
-		<contributor>
-			<name>Anakar Parida</name>
-			<organization>Individual</organization>
-			<timezone>+5.5</timezone>
-			<roles>
-				<role>Contributor</role>
-			</roles>
-		</contributor>
-		<contributor>
-			<name>Rustam Mehmandarov</name>
-			<organization>Individual</organization>
-			<timezone>+3</timezone>
-			<roles>
-				<role>Contributor</role>
-			</roles>
-		</contributor>
-		<contributor>
-			<name>Nathan Scott</name>
-			<email>nathans@redhat.com</email>
-			<organization>Red Hat</organization>
-			<timezone>+10</timezone>
-			<roles>
-				<role>Contributor Emeritus</role>
-			</roles>
-		</contributor>
-		<contributor>
-			<!-- id>duckasteroid</id -->
-			<name>Chris Senior</name>
-			<email>christopher.senior@gmail.com</email>
-			<organization>Snap-on Inc.</organization>
-			<roles>
-				<role>Expert Emeritus</role>
-			</roles>
-		</contributor>
-		<contributor>
-			<!-- id>leomrlima</id -->
-			<name>Leonardo de Moura Rocha Lima</name>
-			<email>llima@v2com.mobi</email>
-			<organization>V2COM</organization>
-			<organizationUrl>http://www.v2com.mobi/</organizationUrl>
-			<timezone>-5</timezone>
-			<roles>
-				<role>Expert Emeritus</role>
-				<role>Java Developer</role>
-			</roles>
-		</contributor>
-		<contributor>
-			<!-- id>eralmas7</id -->
-			<name>Almas Shaikh</name>
-			<email>eralmas7@yahoo.com</email>
-			<organization>Individual / JP Morgan</organization>
-			<timezone>+5.5</timezone>
-			<roles>
-				<role>Test Engineer</role>
-			</roles>
-		</contributor>
-		<contributor>
-			<!-- id>rajmahendra</id -->
-			<name>Rajmahendra Hegde</name>
-			<email>rajmahendra@gmail.com</email>
-			<organization>JUG Chennai</organization>
-			<timezone>+5.5</timezone>
-			<roles>
-				<role>Expert Emeritus</role>
-			</roles>
-		</contributor>
-		<contributor>
-			<!-- id>karen_legrand</id -->
-			<name>Karen Legrand</name>
-			<email>karen.legrand@iem.com</email>
-			<organization>Innovation Emergency Management (IEM)</organization>
-			<organizationUrl>http://www.iem.com</organizationUrl>
-			<timezone>-5</timezone>
-			<roles>
-				<role>Expert Emeritus</role>
-			</roles>
-		</contributor>
-		<contributor>
-			<!-- id>mohamed-taman</id -->
-			<name>Mohamed Mahmoud Taman</name>
-			<email>mohamed.taman@gmail.com</email>
-			<organization>Individual / Morocco JUG</organization>
-			<timezone>+2</timezone>
-			<roles>
-				<role>Expert Emeritus</role>
-			</roles>
-		</contributor>
-		<contributor>
-			<name>Daniel Leuck</name>
-			<email>dan@ikayzo.com</email>
-			<organization>Ikayzo</organization>
-			<timezone>-9</timezone>
-			<roles>
-				<role>Supporter</role>
-			</roles>
-		</contributor>
-		<contributor>
-			<name>Eric Russell</name>
-			<email>eric-r@northwestern.edu</email>
-			<timezone>-5</timezone>
-			<roles>
-				<role>Supporter</role>
-			</roles>
-		</contributor>
-		<contributor>
-			<name>John Paul Morrison</name>
-			<organization>J.P. Morrison Enterprises, Ltd.</organization>
-			<timezone>-5</timezone>
-			<roles>
-				<role>Supporter</role>
-			</roles>
-		</contributor>
-		<contributor>
-			<name>Michael Gruebsch</name>
-			<email>michael@mkm-rabis.de</email>
-			<roles>
-				<role>Supporter</role>
-			</roles>
-			<timezone>+1</timezone>
-		</contributor>
-	</contributors>
+    <!-- Developers and Contributors -->
+    <developers>
+        <developer>
+            <id>dautelle</id>
+            <name>Jean-Marie Dautelle</name>
+            <email>jean-marie@dautelle.com</email>
+            <organization>Airbus</organization>
+            <organizationUrl>http://www.airbus.com</organizationUrl>
+            <timezone>+1</timezone>
+            <roles>
+                <role>Architect</role>
+                <role>Java Developer</role>
+                <role>Spec Lead</role>
+            </roles>
+        </developer>
+        <developer>
+            <id>keilw</id>
+            <name>Werner Keil</name>
+            <email>werner.keil@gmx.net</email>
+            <organization>Creative Arts &amp; Technologies</organization>
+            <organizationUrl>http://www.catmedia.us</organizationUrl>
+            <timezone>+1</timezone>
+            <roles>
+                <role>Architect</role>
+                <role>Java Developer</role>
+                <role>Spec Lead</role>
+            </roles>
+        </developer>
+        <developer>
+            <id>otaviojava</id>
+            <name>Otávio Gonçalves de Santana</name>
+            <email>otaviopolianasantana@gmail.com</email>
+            <organization>Individual / SouJava</organization>
+            <timezone>-5</timezone>
+            <roles>
+                <role>Expert</role>
+                <role>Java Developer</role>
+                <role>Spec Lead</role>
+            </roles>
+        </developer>
+        <developer>
+            <id>desruisseaux</id>
+            <name>Martin Desruisseaux</name>
+            <email>martin.desruisseaux@geomatys.com</email>
+            <organization>Geomatys</organization>
+            <organizationUrl>http://www.geomatys.com</organizationUrl>
+            <timezone>+1</timezone>
+            <roles>
+                <role>Expert</role>
+                <role>Java Developer</role>
+                <role>Architect</role>
+            </roles>
+        </developer>
+        <developer>
+            <id>thodorisbais</id>
+            <name>Thodoris Bais</name>
+            <email>thodoris.bais@gmail.com</email>
+            <organization>Individual / Utrecht JUG</organization>
+            <timezone>+1</timezone>
+            <roles>
+                <role>Expert</role>
+                <role>Java Developer</role>
+            </roles>
+        </developer>
+        <developer>
+            <id>Daniel-Dos</id>
+            <name>Daniel Dias</name>
+            <email>daniel.dias.analistati@gmail.com</email>
+            <organization>Individual / SouJava</organization>
+            <timezone>-5</timezone>
+            <roles>
+                <role>Expert</role>
+                <role>Java Developer</role>
+            </roles>
+        </developer>
+        <developer>
+            <id>jhg023</id>
+            <name>Jacob Glickman</name>
+            <organization>Individual</organization>
+            <timezone>-4</timezone>
+            <roles>
+                <role>Expert</role>
+                <role>Java Developer</role>
+            </roles>
+        </developer>
+        <developer>
+            <id>magesh678</id>
+            <name>Magesh Kasthuri</name>
+            <organization>Individual</organization>
+            <timezone>+4</timezone>
+            <roles>
+                <role>Expert</role>
+                <role>Java Developer</role>
+            </roles>
+        </developer>
+        <developer>
+            <id>mohalmo</id>
+            <name>Mohammed Al-Moayed</name>
+            <organization>Individual</organization>
+            <timezone>+2</timezone>
+            <roles>
+                <role>Expert</role>
+                <role>Java Developer</role>
+            </roles>
+        </developer>
+    </developers>
+    <contributors>
+        <contributor>
+            <name>Andi Huber</name>
+            <organization>Individual</organization>
+            <timezone>+1</timezone>
+            <roles>
+                <role>Contributor</role>
+            </roles>
+        </contributor>
+        <contributor>
+            <name>Filip Van Laenen</name>
+            <email>fvl@computas.com</email>
+            <organization>Computas</organization>
+            <timezone>+1</timezone>
+            <roles>
+                <role>Contributor</role>
+            </roles>
+        </contributor>
+        <contributor>
+            <name>Mads Opheim</name>
+            <organization>Computas</organization>
+            <timezone>+1</timezone>
+            <roles>
+                <role>Contributor</role>
+            </roles>
+        </contributor>
+        <contributor>
+            <name>Matthijs Thoolen</name>
+            <organization>Utrecht Java User Group</organization>
+            <timezone>+1</timezone>
+            <roles>
+                <role>Contributor</role>
+            </roles>
+        </contributor>
+        <contributor>
+            <name>Anakar Parida</name>
+            <organization>Individual</organization>
+            <timezone>+5.5</timezone>
+            <roles>
+                <role>Contributor</role>
+            </roles>
+        </contributor>
+        <contributor>
+            <name>Rustam Mehmandarov</name>
+            <organization>Individual</organization>
+            <timezone>+3</timezone>
+            <roles>
+                <role>Contributor</role>
+            </roles>
+        </contributor>
+        <contributor>
+            <name>Nathan Scott</name>
+            <email>nathans@redhat.com</email>
+            <organization>Red Hat</organization>
+            <timezone>+10</timezone>
+            <roles>
+                <role>Contributor Emeritus</role>
+            </roles>
+        </contributor>
+        <contributor>
+            <!-- id>duckasteroid</id -->
+            <name>Chris Senior</name>
+            <email>christopher.senior@gmail.com</email>
+            <organization>Snap-on Inc.</organization>
+            <roles>
+                <role>Expert Emeritus</role>
+            </roles>
+        </contributor>
+        <contributor>
+            <!-- id>leomrlima</id -->
+            <name>Leonardo de Moura Rocha Lima</name>
+            <email>llima@v2com.mobi</email>
+            <organization>V2COM</organization>
+            <organizationUrl>http://www.v2com.mobi/</organizationUrl>
+            <timezone>-5</timezone>
+            <roles>
+                <role>Expert Emeritus</role>
+                <role>Java Developer</role>
+            </roles>
+        </contributor>
+        <contributor>
+            <!-- id>eralmas7</id -->
+            <name>Almas Shaikh</name>
+            <email>eralmas7@yahoo.com</email>
+            <organization>Individual / JP Morgan</organization>
+            <timezone>+5.5</timezone>
+            <roles>
+                <role>Test Engineer</role>
+            </roles>
+        </contributor>
+        <contributor>
+            <!-- id>rajmahendra</id -->
+            <name>Rajmahendra Hegde</name>
+            <email>rajmahendra@gmail.com</email>
+            <organization>JUG Chennai</organization>
+            <timezone>+5.5</timezone>
+            <roles>
+                <role>Expert Emeritus</role>
+            </roles>
+        </contributor>
+        <contributor>
+            <!-- id>karen_legrand</id -->
+            <name>Karen Legrand</name>
+            <email>karen.legrand@iem.com</email>
+            <organization>Innovation Emergency Management (IEM)</organization>
+            <organizationUrl>http://www.iem.com</organizationUrl>
+            <timezone>-5</timezone>
+            <roles>
+                <role>Expert Emeritus</role>
+            </roles>
+        </contributor>
+        <contributor>
+            <!-- id>mohamed-taman</id -->
+            <name>Mohamed Mahmoud Taman</name>
+            <email>mohamed.taman@gmail.com</email>
+            <organization>Individual / Morocco JUG</organization>
+            <timezone>+2</timezone>
+            <roles>
+                <role>Expert Emeritus</role>
+            </roles>
+        </contributor>
+        <contributor>
+            <name>Daniel Leuck</name>
+            <email>dan@ikayzo.com</email>
+            <organization>Ikayzo</organization>
+            <timezone>-9</timezone>
+            <roles>
+                <role>Supporter</role>
+            </roles>
+        </contributor>
+        <contributor>
+            <name>Eric Russell</name>
+            <email>eric-r@northwestern.edu</email>
+            <timezone>-5</timezone>
+            <roles>
+                <role>Supporter</role>
+            </roles>
+        </contributor>
+        <contributor>
+            <name>John Paul Morrison</name>
+            <organization>J.P. Morrison Enterprises, Ltd.</organization>
+            <timezone>-5</timezone>
+            <roles>
+                <role>Supporter</role>
+            </roles>
+        </contributor>
+        <contributor>
+            <name>Michael Gruebsch</name>
+            <email>michael@mkm-rabis.de</email>
+            <roles>
+                <role>Supporter</role>
+            </roles>
+            <timezone>+1</timezone>
+        </contributor>
+    </contributors>
 
-	<build>
-		<pluginManagement>
-			<plugins>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-compiler-plugin</artifactId>
-					<version>${maven.compiler.version}</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-antrun-plugin</artifactId>
-					<version>1.8</version>
-				</plugin>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven.compiler.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                    <version>1.8</version>
+                </plugin>
 
-				<!-- License -->
-				<plugin>
-					<groupId>com.mycila</groupId>
-					<artifactId>license-maven-plugin</artifactId>
-					<version>${license-maven.version}</version>
-					<executions>
-						<execution>
-							<goals>
-								<goal>check</goal>
-							</goals>
-						</execution>
-					</executions>
-				</plugin>
+                <!-- License -->
+                <plugin>
+                    <groupId>com.mycila</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>${license-maven.version}</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
 
-				<!-- Format -->
-				<plugin>
-					<groupId>net.revelc.code</groupId>
-					<artifactId>formatter-maven-plugin</artifactId>
-					<version>0.5.2</version>
-				</plugin>
+                <!-- Format -->
+                <plugin>
+                    <groupId>net.revelc.code</groupId>
+                    <artifactId>formatter-maven-plugin</artifactId>
+                    <version>0.5.2</version>
+                </plugin>
 
-				<!--This plugin's configuration is used to store Eclipse m2e settings
-					only. It has no influence on the Maven build itself. -->
-				<plugin>
-					<groupId>org.eclipse.m2e</groupId>
-					<artifactId>lifecycle-mapping</artifactId>
-					<version>1.0.0</version>
-					<configuration>
-						<lifecycleMappingMetadata>
-							<pluginExecutions>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>org.jacoco</groupId>
-										<artifactId>
-											jacoco-maven-plugin
-										</artifactId>
-										<versionRange>
-											[0.7.1.201405082137,)
-										</versionRange>
-										<goals>
-											<goal>prepare-agent</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore></ignore>
-									</action>
-								</pluginExecution>
-								<pluginExecution>
-									<pluginExecutionFilter>
-										<groupId>
-											net.revelc.code
-										</groupId>
-										<artifactId>
-											formatter-maven-plugin
-										</artifactId>
-										<versionRange>
-											[0.5.2,)
-										</versionRange>
-										<goals>
-											<goal>format</goal>
-										</goals>
-									</pluginExecutionFilter>
-									<action>
-										<ignore></ignore>
-									</action>
-								</pluginExecution>
-							</pluginExecutions>
-						</lifecycleMappingMetadata>
-					</configuration>
-				</plugin>
-			</plugins>
-		</pluginManagement>
+                <!--This plugin's configuration is used to store Eclipse m2e settings only.
+                    It has no influence on the Maven build itself. -->
+                <plugin>
+                    <groupId>org.eclipse.m2e</groupId>
+                    <artifactId>lifecycle-mapping</artifactId>
+                    <version>1.0.0</version>
+                    <configuration>
+                        <lifecycleMappingMetadata>
+                            <pluginExecutions>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>org.jacoco</groupId>
+                                        <artifactId>
+                                            jacoco-maven-plugin
+                                        </artifactId>
+                                        <versionRange>
+                                            [0.7.1.201405082137,)
+                                        </versionRange>
+                                        <goals>
+                                            <goal>prepare-agent</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
+                                <pluginExecution>
+                                    <pluginExecutionFilter>
+                                        <groupId>
+                                            net.revelc.code
+                                        </groupId>
+                                        <artifactId>
+                                            formatter-maven-plugin
+                                        </artifactId>
+                                        <versionRange>
+                                            [0.5.2,)
+                                        </versionRange>
+                                        <goals>
+                                            <goal>format</goal>
+                                        </goals>
+                                    </pluginExecutionFilter>
+                                    <action>
+                                        <ignore></ignore>
+                                    </action>
+                                </pluginExecution>
+                            </pluginExecutions>
+                        </lifecycleMappingMetadata>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
 
-		<plugins>
-			<!-- Compilation -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<release>${maven.compile.targetLevel}</release>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-antrun-plugin</artifactId>
-				<executions>
-					<execution>
-						<phase>prepare-package</phase>
-						<goals>
-							<goal>run</goal>
-						</goals>
-						<configuration>
-							<target>
-								<mkdir
-									dir="${project.build.directory}/classes/META-INF/versions/${jdkOptionalVersion}" />
-								<javac
-									destdir="${project.build.directory}/classes/META-INF/versions/${jdkOptionalVersion}"
-									srcdir="${project.basedir}/src/main/jdk${jdkOptionalVersion}"
-									includeAntRuntime="false">
-									<compilerarg
-										line="--release=${jdkOptionalVersion} --patch-module java.measure=${project.build.directory}/classes" />
-								</javac>
-							</target>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
+        <plugins>
+            <!-- Compilation -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>${maven.compile.targetLevel}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <mkdir
+                                    dir="${project.build.directory}/classes/META-INF/versions/${jdkOptionalVersion}" />
+                                <javac
+                                    destdir="${project.build.directory}/classes/META-INF/versions/${jdkOptionalVersion}"
+                                    srcdir="${project.basedir}/src/main/jdk${jdkOptionalVersion}"
+                                    includeAntRuntime="false">
+                                    <compilerarg
+                                        line="--release=${jdkOptionalVersion} --patch-module java.measure=${project.build.directory}/classes" />
+                                </javac>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
-			<!-- Need to specificy at least 2.22.0 for JUnit 5 -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<configuration>
-					<forkCount>1.5C</forkCount>
-				</configuration>
-			</plugin>
+            <!-- Need to specificy at least 2.22.0 for JUnit 5 -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <forkCount>1.5C</forkCount>
+                </configuration>
+            </plugin>
 
-			<!-- Coverage -->
-			<plugin>
-				<groupId>org.jacoco</groupId>
-				<artifactId>jacoco-maven-plugin</artifactId>
-				<configuration>
-					<excludes>
-						<exclude>META-INF/versions/**</exclude>
-					</excludes>
-				</configuration>
-				<executions>
-					<execution>
-						<id>pre-unit-test</id>
-						<goals>
-							<goal>prepare-agent</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>post-unit-test</id>
-						<phase>test</phase>
-						<goals>
-							<goal>report</goal>
-							<goal>check</goal>
-						</goals>
-						<configuration>
-							<rules>
-								<rule>
-									<element>BUNDLE</element>
-									<limits>
-										<limit
-											implementation="org.jacoco.report.check.Limit">
-											<counter>INSTRUCTION</counter>
-											<value>COVEREDRATIO</value>
-											<minimum>0.5</minimum>
-										</limit>
-										<limit>
-											<counter>COMPLEXITY</counter>
-											<value>COVEREDRATIO</value>
-											<minimum>0.5</minimum>
-										</limit>
-									</limits>
-								</rule>
-							</rules>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
+            <!-- Coverage -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>META-INF/versions/**</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>pre-unit-test</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>post-unit-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit
+                                            implementation="org.jacoco.report.check.Limit">
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.5</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.5</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
-			<plugin>
-				<groupId>org.eluder.coveralls</groupId>
-				<artifactId>coveralls-maven-plugin</artifactId>
-				<version>4.3.0</version>
-				<dependencies>
-					<dependency>
-						<groupId>javax.xml.bind</groupId>
-						<artifactId>jaxb-api</artifactId>
-						<version>2.2.3</version>
-					</dependency>
-				</dependencies>
-				<configuration>
-					<repoToken>${env.COVERALLS_REPO_TOKEN}</repoToken>
-				</configuration>
-			</plugin>
+            <plugin>
+                <groupId>org.eluder.coveralls</groupId>
+                <artifactId>coveralls-maven-plugin</artifactId>
+                <version>4.3.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                        <version>2.2.3</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <repoToken>${env.COVERALLS_REPO_TOKEN}</repoToken>
+                </configuration>
+            </plugin>
 
-			<!-- Attach Sources -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-source-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>attach-sources</id>
-						<phase>package</phase>
-						<goals>
-							<goal>jar-no-fork</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+            <!-- Attach Sources -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>attach-javadocs</id>
-						<goals>
-							<goal>jar</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<!-- Workaround for
-					https://github.com/unitsofmeasurement/unit-api/issues/220 -->
-					<source>8</source>
-				</configuration>
-			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <!-- Workaround for https://github.com/unitsofmeasurement/unit-api/issues/220 -->
+                    <source>8</source>
+                </configuration>
+            </plugin>
 
-			<!-- JAR packaging -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-jar-plugin</artifactId>
-				<configuration>
-					<archive>
-						<manifest>
-							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-						</manifest>
-						<manifestEntries>
-							<Specification-Title>${project.name}</Specification-Title>
-							<Specification-Version>${project.version}</Specification-Version>
-							<Specification-Vendor>${project.organization.name}</Specification-Vendor>
-							<Automatic-Module-Name>java.measure</Automatic-Module-Name>
-							<Multi-Release>true</Multi-Release>
-						</manifestEntries>
-						<addMavenDescriptor>false</addMavenDescriptor>
-					</archive>
-				</configuration>
+            <!-- JAR packaging -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                        <manifestEntries>
+                            <Specification-Title>${project.name}</Specification-Title>
+                            <Specification-Version>${project.version}</Specification-Version>
+                            <Specification-Vendor>${project.organization.name}</Specification-Vendor>
+                            <Automatic-Module-Name>java.measure</Automatic-Module-Name>
+                            <Multi-Release>true</Multi-Release>
+                        </manifestEntries>
+                        <addMavenDescriptor>false</addMavenDescriptor>
+                    </archive>
+                </configuration>
 
-				<executions>
-					<execution>
-						<goals>
-							<goal>test-jar</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
-			<!-- Packaging (OSGi bundle) -->
-			<plugin>
-				<groupId>org.apache.felix</groupId>
-				<artifactId>maven-bundle-plugin</artifactId>
-				<extensions>true</extensions>
-				<configuration>
-					<instructions>
-						<Import-Package>
-							!jakarta.annotation,!jakarta.inject,!javax.annotation,!javax.inject,*</Import-Package>
-					</instructions>
-				</configuration>
-			</plugin>
+            <!-- Packaging (OSGi bundle) -->
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>
+                            !jakarta.annotation,!jakarta.inject,!javax.annotation,!javax.inject,*</Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
 
-			<!-- Resources -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-resources-plugin</artifactId>
-				<configuration>
-					<encoding>${project.build.sourceEncoding}</encoding>
-				</configuration>
-			</plugin>
+            <!-- Resources -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <configuration>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
 
-			<!-- ======================================================= -->
-			<!-- Maven License Plugin -->
-			<!-- ======================================================= -->
-			<plugin>
-				<groupId>com.mycila</groupId>
-				<artifactId>license-maven-plugin</artifactId>
-				<configuration>
-					<licenseSets>
-						<licenseSet>
-							<header>src/main/config/header.txt</header>
-							<properties>
-								<owner>${project.organization.name}</owner>
-								<currentYear>${thisYear}</currentYear>
-							</properties>
-							<excludes>
-								<exclude>.editorconfig</exclude>
-								<exclude>.gitattributes</exclude>
-								<exclude>.github/**</exclude>
-								<exclude>.circleci/**</exclude>
-								<exclude>**/LICENSE</exclude>
-								<exclude>**/README</exclude>
-								<exclude>**/pom.xml</exclude>
-								<exclude>**/settings.xml</exclude>
-								<exclude>docs/**</exclude>
-								<exclude>src/test/resources/**</exclude>
-								<exclude>src/main/resources/**</exclude>
-								<exclude>src/main/config/**</exclude>
-								<exclude>src/main/emf/**</exclude>
-								<exclude>src/site/**</exclude>
-								<exclude>src/etc/**</exclude>
-								<exclude>*.css</exclude>
-								<exclude>*.jpg</exclude>
-								<exclude>*.png</exclude>
-								<exclude>*.yml</exclude>
-							</excludes>
-							<headerDefinitions>
-								<headerDefinition>src/main/config/headers.xml</headerDefinition>
-							</headerDefinitions>
-						</licenseSet>
-					</licenseSets>
-					<mapping>
-						<java>JAVA_STYLE</java>
-					</mapping>
-				</configuration>
-			</plugin>
+            <!-- Maven License Plugin -->
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <licenseSets>
+                        <licenseSet>
+                            <header>src/main/config/header.txt</header>
+                            <properties>
+                                <owner>${project.organization.name}</owner>
+                                <currentYear>${thisYear}</currentYear>
+                            </properties>
+                            <excludes>
+                                <exclude>.editorconfig</exclude>
+                                <exclude>.gitattributes</exclude>
+                                <exclude>.github/**</exclude>
+                                <exclude>.circleci/**</exclude>
+                                <exclude>**/LICENSE</exclude>
+                                <exclude>**/README</exclude>
+                                <exclude>**/pom.xml</exclude>
+                                <exclude>**/settings.xml</exclude>
+                                <exclude>docs/**</exclude>
+                                <exclude>src/test/resources/**</exclude>
+                                <exclude>src/main/resources/**</exclude>
+                                <exclude>src/main/config/**</exclude>
+                                <exclude>src/main/emf/**</exclude>
+                                <exclude>src/site/**</exclude>
+                                <exclude>src/etc/**</exclude>
+                                <exclude>*.css</exclude>
+                                <exclude>*.jpg</exclude>
+                                <exclude>*.png</exclude>
+                                <exclude>*.yml</exclude>
+                            </excludes>
+                            <headerDefinitions>
+                                <headerDefinition>src/main/config/headers.xml</headerDefinition>
+                            </headerDefinitions>
+                        </licenseSet>
+                    </licenseSets>
+                    <mapping>
+                        <java>JAVA_STYLE</java>
+                    </mapping>
+                </configuration>
+            </plugin>
 
-			<!-- ======================================================= -->
-			<!-- Maven Code Formatter -->
-			<!-- ======================================================= -->
-			<plugin>
-				<groupId>net.revelc.code</groupId>
-				<artifactId>formatter-maven-plugin</artifactId>
-				<configuration>
-					<configFile>
-						${project.basedir}/src/main/config/eclipse-formatter-config.xml</configFile>
-				</configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>format</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
+            <!-- Maven Code Formatter -->
+            <plugin>
+                <groupId>net.revelc.code</groupId>
+                <artifactId>formatter-maven-plugin</artifactId>
+                <configuration>
+                    <configFile>
+                        ${project.basedir}/src/main/config/eclipse-formatter-config.xml
+                    </configFile>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
-			<!-- Maven web site -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-site-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
+            <!-- Maven web site -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
 
-	<reporting>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-project-info-reports-plugin</artifactId>
-				<version>3.1.0</version>
-				<reportSets>
-					<reportSet>
-						<reports>
-							<report>index</report>
-							<report>summary</report>
-							<report>licenses</report>
-							<report>scm</report>
-							<report>ci-management</report>
-							<report>team</report>
-							<report>mailing-lists</report>
-							<report>issue-management</report>
-						</reports>
-					</reportSet>
-				</reportSets>
-			</plugin>
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin</artifactId>
+                <version>3.1.0</version>
+                <reportSets>
+                    <reportSet>
+                        <reports>
+                            <report>index</report>
+                            <report>summary</report>
+                            <report>licenses</report>
+                            <report>scm</report>
+                            <report>ci-management</report>
+                            <report>team</report>
+                            <report>mailing-lists</report>
+                            <report>issue-management</report>
+                        </reports>
+                    </reportSet>
+                </reportSets>
+            </plugin>
 
-			<!-- Javadoc generation -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>${maven.javadoc.version}</version>
-				<configuration>
-					<source>${maven.compile.sourceLevel}</source>
-					<encoding>${project.build.sourceEncoding}</encoding>
-					<docencoding>${project.reporting.outputEncoding}</docencoding>
-					<charset>${project.reporting.outputEncoding}</charset>
-					<locale>en</locale>
-					<detectJavaApiLink>false</detectJavaApiLink>
-					<noqualifier>all</noqualifier>
-					<quiet>true</quiet>
-					<keywords>true</keywords>
-					<links>
-						<link>http://docs.oracle.com/javase/11/docs/api/</link>
-					</links>
-				</configuration>
-			</plugin>
+            <!-- Javadoc generation -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven.javadoc.version}</version>
+                <configuration>
+                    <source>${maven.compile.sourceLevel}</source>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <docencoding>${project.reporting.outputEncoding}</docencoding>
+                    <charset>${project.reporting.outputEncoding}</charset>
+                    <locale>en</locale>
+                    <detectJavaApiLink>false</detectJavaApiLink>
+                    <noqualifier>all</noqualifier>
+                    <quiet>true</quiet>
+                    <keywords>true</keywords>
+                    <links>
+                        <link>http://docs.oracle.com/javase/11/docs/api/</link>
+                    </links>
+                </configuration>
+            </plugin>
 
-			<!-- Code analysis -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-pmd-plugin</artifactId>
-				<version>3.13.0</version>
-				<configuration>
-					<sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
-				</configuration>
-			</plugin>
+            <!-- Code analysis -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <sourceEncoding>${project.build.sourceEncoding}</sourceEncoding>
+                </configuration>
+            </plugin>
 
-			<!-- Report on test results -->
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-report-plugin</artifactId>
-				<version>${maven.surefire-report.version}</version>
-			</plugin>
+            <!-- Report on test results -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-report-plugin</artifactId>
+                <version>${maven.surefire-report.version}</version>
+            </plugin>
 
-			<!-- Static analysis for occurrences of bug patterns -->
-			<plugin>
-				<groupId>com.github.spotbugs</groupId>
-				<artifactId>spotbugs-maven-plugin</artifactId>
-				<version>${spotbugs-maven.version}</version>
-			</plugin>
-		</plugins>
-	</reporting>
+            <!-- Static analysis for occurrences of bug patterns -->
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <version>${spotbugs-maven.version}</version>
+            </plugin>
+        </plugins>
+    </reporting>
 
-	<!-- Deployment to public servers -->
-	<distributionManagement>
-		<repository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-		</repository>
-		<snapshotRepository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-		</snapshotRepository>
-		<site>
-			<id>JSR-385</id>
-			<name>JSR-385 Maven reports</name>
-			<url>file:///var/www/www.unitsofmeasurement.github.io/unit-api</url>
-			<!-- No longer active, just a placeholder! -->
-		</site>
-	</distributionManagement>
+    <!-- Deployment to public servers -->
+    <distributionManagement>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <site>
+            <id>JSR-385</id>
+            <name>JSR-385 Maven reports</name>
+            <url>file:///var/www/www.unitsofmeasurement.github.io/unit-api</url>
+            <!-- No longer active, just a placeholder! -->
+        </site>
+    </distributionManagement>
 
-	<dependencies>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
-			<version>${junit.jupiter.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<version>${junit.jupiter.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>jakarta.inject</groupId>
-			<artifactId>jakarta.inject-api</artifactId>
-			<version>${jakarta.inject.version}</version>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <version>${jakarta.inject.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
-	<!-- Additional repositories -->
-	<!-- Helps to resolve Parent POM and Snapshot artifacts -->
-	<repositories>
-		<repository>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-			<id>ossrh-snapshot</id>
-			<name>OSSRH Snapshots</name>
-			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-		</repository>
-	</repositories>
+    <!-- Additional repositories -->
+    <!-- Helps to resolve Parent POM and Snapshot artifacts -->
+    <repositories>
+        <repository>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <id>ossrh-snapshot</id>
+            <name>OSSRH Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
 
-	<profiles>
-		<!-- Individual JARs -->
-		<profile>
-			<id>base-jar</id>
-			<!-- This profile builds only the base (root level) elements into a
-			separate JAR file -->
-			<activation>
-				<activeByDefault>false</activeByDefault>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-antrun-plugin</artifactId>
-						<executions>
-							<execution>
-								<phase>prepare-package</phase>
-								<goals>
-									<goal>run</goal>
-								</goals>
-								<configuration>
-									<target>
-										<mkdir
-											dir="${project.build.directory}/classes/META-INF/versions/${jdkOptionalVersion}" />
-										<javac
-											destdir="${project.build.directory}/classes/META-INF/versions/${jdkOptionalVersion}"
-											srcdir="${project.basedir}/src/etc/modules/base/jdk${jdkOptionalVersion}"
-											includeAntRuntime="false">
-											<compilerarg
-												line="--release=${jdkOptionalVersion} --patch-module java.measure.base=${project.build.directory}/classes" />
-										</javac>
-									</target>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
+    <profiles>
+        <!-- Individual JARs -->
+        <profile>
+            <id>base-jar</id>
+            <!-- This profile builds only the base (root level) elements into a separate JAR file -->
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <mkdir
+                                            dir="${project.build.directory}/classes/META-INF/versions/${jdkOptionalVersion}" />
+                                        <javac
+                                            destdir="${project.build.directory}/classes/META-INF/versions/${jdkOptionalVersion}"
+                                            srcdir="${project.basedir}/src/etc/modules/base/jdk${jdkOptionalVersion}"
+                                            includeAntRuntime="false">
+                                            <compilerarg
+                                                line="--release=${jdkOptionalVersion} --patch-module java.measure.base=${project.build.directory}/classes" />
+                                        </javac>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
 
-					<plugin>
-						<artifactId>maven-jar-plugin</artifactId>
-						<configuration>
-							<archive>
-								<manifest>
-									<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-								</manifest>
-								<manifestEntries>
-									<Specification-Title>${project.name}</Specification-Title>
-									<Specification-Version>${project.version}</Specification-Version>
-									<Specification-Vendor>
-										${project.organization.name}</Specification-Vendor>
-									<Automatic-Module-Name>java.measure.base</Automatic-Module-Name>
-									<Multi-Release>true</Multi-Release>
-								</manifestEntries>
-								<addMavenDescriptor>false</addMavenDescriptor>
-							</archive>
-						</configuration>
-						<executions>
-							<execution>
-								<id>base-jar</id>
-								<goals>
-									<goal>jar</goal>
-								</goals>
-								<configuration>
-									<classifier>base</classifier>
-									<excludes>
-										<exclude>javax/measure/format/**</exclude>
-										<exclude>javax/measure/quantity/**</exclude>
-										<exclude>javax/measure/spi/**</exclude>
-									</excludes>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
+                    <plugin>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                </manifest>
+                                <manifestEntries>
+                                    <Specification-Title>${project.name}</Specification-Title>
+                                    <Specification-Version>${project.version}</Specification-Version>
+                                    <Specification-Vendor>
+                                        ${project.organization.name}</Specification-Vendor>
+                                    <Automatic-Module-Name>java.measure.base</Automatic-Module-Name>
+                                    <Multi-Release>true</Multi-Release>
+                                </manifestEntries>
+                                <addMavenDescriptor>false</addMavenDescriptor>
+                            </archive>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>base-jar</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <classifier>base</classifier>
+                                    <excludes>
+                                        <exclude>javax/measure/format/**</exclude>
+                                        <exclude>javax/measure/quantity/**</exclude>
+                                        <exclude>javax/measure/spi/**</exclude>
+                                    </excludes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 
-		<profile>
-			<id>format-jar</id>
-			<!-- This profile builds (optional) format elements into separate
-			JAR files -->
-			<build>
-				<plugins>
-					<plugin>
-						<artifactId>maven-jar-plugin</artifactId>
-						<version>${maven.jar.version}</version>
-						<configuration>
-							<archive>
-								<manifest>
-									<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-								</manifest>
-								<manifestEntries>
-									<Specification-Title>${project.name}</Specification-Title>
-									<Specification-Version>${project.version}</Specification-Version>
-									<Specification-Vendor>
-										${project.organization.name}</Specification-Vendor>
-									<Automatic-Module-Name>java.measure.format</Automatic-Module-Name>
-									<Multi-Release>false</Multi-Release>
-								</manifestEntries>
-								<addMavenDescriptor>false</addMavenDescriptor>
-							</archive>
-						</configuration>
-						<executions>
-							<execution>
-								<id>format-jar</id>
-								<goals>
-									<goal>jar</goal>
-								</goals>
-								<configuration>
-									<classifier>format</classifier>
-									<includes>
-										<include>javax/measure/format/**</include>
-									</includes>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
+        <profile>
+            <id>format-jar</id>
+            <!-- This profile builds (optional) format elements into separate JAR files -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <version>${maven.jar.version}</version>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                </manifest>
+                                <manifestEntries>
+                                    <Specification-Title>${project.name}</Specification-Title>
+                                    <Specification-Version>${project.version}</Specification-Version>
+                                    <Specification-Vendor>
+                                        ${project.organization.name}</Specification-Vendor>
+                                    <Automatic-Module-Name>java.measure.format</Automatic-Module-Name>
+                                    <Multi-Release>false</Multi-Release>
+                                </manifestEntries>
+                                <addMavenDescriptor>false</addMavenDescriptor>
+                            </archive>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>format-jar</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <classifier>format</classifier>
+                                    <includes>
+                                        <include>javax/measure/format/**</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 
-		<profile>
-			<id>quantity-jar</id>
-			<!-- This profile builds (optional) quantities into separate JAR
-			files -->
-			<build>
-				<plugins>
-					<plugin>
-						<artifactId>maven-jar-plugin</artifactId>
-						<version>${maven.jar.version}</version>
-						<configuration>
-							<archive>
-								<manifest>
-									<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-								</manifest>
-								<manifestEntries>
-									<Specification-Title>${project.name}</Specification-Title>
-									<Specification-Version>${project.version}</Specification-Version>
-									<Specification-Vendor>
-										${project.organization.name}</Specification-Vendor>
-									<Automatic-Module-Name>java.measure.quantity</Automatic-Module-Name>
-									<Multi-Release>false</Multi-Release>
-								</manifestEntries>
-								<addMavenDescriptor>false</addMavenDescriptor>
-							</archive>
-						</configuration>
-						<executions>
-							<execution>
-								<id>quanity-jar</id>
-								<goals>
-									<goal>jar</goal>
-								</goals>
-								<configuration>
-									<classifier>quantity</classifier>
-									<includes>
-										<include>javax/measure/quantity/**</include>
-									</includes>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
+        <profile>
+            <id>quantity-jar</id>
+            <!-- This profile builds (optional) quantities into separate JAR files -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <version>${maven.jar.version}</version>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                </manifest>
+                                <manifestEntries>
+                                    <Specification-Title>${project.name}</Specification-Title>
+                                    <Specification-Version>${project.version}</Specification-Version>
+                                    <Specification-Vendor>
+                                        ${project.organization.name}</Specification-Vendor>
+                                    <Automatic-Module-Name>java.measure.quantity</Automatic-Module-Name>
+                                    <Multi-Release>false</Multi-Release>
+                                </manifestEntries>
+                                <addMavenDescriptor>false</addMavenDescriptor>
+                            </archive>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>quanity-jar</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <classifier>quantity</classifier>
+                                    <includes>
+                                        <include>javax/measure/quantity/**</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 
-		<profile>
-			<id>spi-jar</id>
-			<!-- This profile builds (optional) SPI into separate JAR files -->
-			<build>
-				<plugins>
-					<plugin>
-						<artifactId>maven-jar-plugin</artifactId>
-						<version>${maven.jar.version}</version>
-						<configuration>
-							<archive>
-								<manifest>
-									<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-								</manifest>
-								<manifestEntries>
-									<Specification-Title>${project.name}</Specification-Title>
-									<Specification-Version>${project.version}</Specification-Version>
-									<Specification-Vendor>
-										${project.organization.name}</Specification-Vendor>
-									<Automatic-Module-Name>java.measure.spi</Automatic-Module-Name>
-									<Multi-Release>false</Multi-Release>
-								</manifestEntries>
-								<addMavenDescriptor>false</addMavenDescriptor>
-							</archive>
-						</configuration>
-						<executions>
-							<execution>
-								<id>spi-jar</id>
-								<goals>
-									<goal>jar</goal>
-								</goals>
-								<configuration>
-									<classifier>spi</classifier>
-									<includes>
-										<include>javax/measure/spi/**</include>
-									</includes>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
+        <profile>
+            <id>spi-jar</id>
+            <!-- This profile builds (optional) SPI into separate JAR files -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <version>${maven.jar.version}</version>
+                        <configuration>
+                            <archive>
+                                <manifest>
+                                    <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                </manifest>
+                                <manifestEntries>
+                                    <Specification-Title>${project.name}</Specification-Title>
+                                    <Specification-Version>${project.version}</Specification-Version>
+                                    <Specification-Vendor>
+                                        ${project.organization.name}</Specification-Vendor>
+                                    <Automatic-Module-Name>java.measure.spi</Automatic-Module-Name>
+                                    <Multi-Release>false</Multi-Release>
+                                </manifestEntries>
+                                <addMavenDescriptor>false</addMavenDescriptor>
+                            </archive>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>spi-jar</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <classifier>spi</classifier>
+                                    <includes>
+                                        <include>javax/measure/spi/**</include>
+                                    </includes>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 
-		<!-- Documentation -->
-		<profile>
-			<id>documentation</id>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.asciidoctor</groupId>
-						<artifactId>asciidoctor-maven-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>output-html</id>
-								<phase>generate-resources</phase>
-								<goals>
-									<goal>process-asciidoc</goal>
-								</goals>
-								<configuration>
-									<outputDirectory>target/docs</outputDirectory>
-									<sourceHighlighter>highlightjs</sourceHighlighter> <!--
+        <!-- Documentation -->
+        <profile>
+            <id>documentation</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctor-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>output-html</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>process-asciidoc</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>target/docs</outputDirectory>
+                                    <sourceHighlighter>highlightjs</sourceHighlighter> <!--
 									coderay -->
-									<backend>html</backend>
-									<embedAssets>true</embedAssets>
-									<imagesDir>src/main/asciidoc/images</imagesDir>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
+                                    <backend>html</backend>
+                                    <embedAssets>true</embedAssets>
+                                    <imagesDir>src/main/asciidoc/images</imagesDir>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 
-		<profile>
-			<id>localCopySite</id>
-			<!-- ======================================================= -->
-			<!-- Locally copies the "site" into the GitHub pages folder  -->
-			<!-- ======================================================= -->
-			<build>
-				<plugins>
-					<plugin>
-						<artifactId>maven-resources-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>copy-resources</id>
-								<phase>site</phase>
-								<goals>
-									<goal>copy-resources</goal>
-								</goals>
-								<configuration>
-									<outputDirectory>${basedir}/docs/site</outputDirectory>
-									<resources>
-										<resource>
-											<directory>target/site</directory>
-											<filtering>false</filtering>
-										</resource>
-									</resources>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
+        <profile>
+            <id>localCopySite</id>
+            <!-- Locally copies the "site" into the GitHub pages folder  -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-resources</id>
+                                <phase>site</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${basedir}/docs/site</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>target/site</directory>
+                                            <filtering>false</filtering>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
 
-		<profile>
-			<id>sonar</id>
-			<activation>
-				<activeByDefault>true</activeByDefault>
-			</activation>
-			<properties>
-				<sonar.host.url>https://sonarcloud.io</sonar.host.url>
-				<sonar.projectKey>${env.SONARCLOUD_PROJECT_KEY}</sonar.projectKey>
-				<sonar.login>${env.SONARCLOUD_LOGIN}</sonar.login>
-				<sonar.organization>${env.SONARCLOUD_ORG}</sonar.organization>
-				<sourceEncoding>UTF-8</sourceEncoding> <!-- in Maven 3. -->
-				<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-				<project.reporting.outputEncoding>${sourceEncoding}</project.reporting.outputEncoding>
-				<jdkVersion>8</jdkVersion>
-				<jdkOptionalVersion>9</jdkOptionalVersion>
-				<project.build.javaVersion>${jdkVersion}</project.build.javaVersion>
-				<maven.compile.targetLevel>${jdkVersion}</maven.compile.targetLevel>
-				<maven.compile.sourceLevel>${jdkVersion}</maven.compile.sourceLevel>
-			</properties>
-		</profile>
-	</profiles>
+        <profile>
+            <id>sonar</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+                <sonar.projectKey>${env.SONARCLOUD_PROJECT_KEY}</sonar.projectKey>
+                <sonar.login>${env.SONARCLOUD_LOGIN}</sonar.login>
+                <sonar.organization>${env.SONARCLOUD_ORG}</sonar.organization>
+                <sourceEncoding>UTF-8</sourceEncoding> <!-- in Maven 3. -->
+                <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+                <project.reporting.outputEncoding>${sourceEncoding}</project.reporting.outputEncoding>
+                <jdkVersion>8</jdkVersion>
+                <jdkOptionalVersion>9</jdkOptionalVersion>
+                <project.build.javaVersion>${jdkVersion}</project.build.javaVersion>
+                <maven.compile.targetLevel>${jdkVersion}</maven.compile.targetLevel>
+                <maven.compile.sourceLevel>${jdkVersion}</maven.compile.sourceLevel>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
This is the application of https://github.com/unitsofmeasurement/unit-api/issues/249.

This pull request contains also the removal of commented-out section of the pom.xml. The removed configurations were:

* Custom (non-standard) javadoc tags.
* Ant task writing files in `classes/META-INF/`. Should not be needed because unit-api is not an implementation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/unit-api/251)
<!-- Reviewable:end -->
